### PR TITLE
Nodejs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an FTP client for Node.js. It supports explicit FTPS over TLS, Passive M
 
 ## Dependencies
 
-Node 7.6 or later is the only dependency.
+Node 8.0 or later is the only dependency.
 
 ## Introduction
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ipv6"
   ],
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=8.0.0"
   },
   "devDependencies": {
     "eslint": "4.19.1",


### PR DESCRIPTION
In docs, you say minimal nodejs version is 7.6, but moving code to a older project, using node 7.10.1, it crashed becouse of `util.Promisify`. [As docs says](https://nodejs.org/api/util.html#util_util_promisify_original), it was added in v8.0.0. 

Also, in your `.travis.yml` [node version is already setted to 8](https://github.com/patrickjuchli/basic-ftp/blob/master/.travis.yml#L4), so I think 8.0 this is the new required node version.