### PR TITLE
add keep alive option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -16,9 +16,10 @@ module.exports = class FTPContext {
      * Instantiate an FTP context.
      * 
      * @param {number} [timeout=0]  Timeout in milliseconds to apply to control and data connections. Use 0 for no timeout.
-     * @param {string} [encoding="utf8"]  Encoding to use for control connection. UTF-8 by default. Use "latin1" for older servers. 
+     * @param {number} [keepAliveInterval=0]  The interval between NOOP commands sent to the server in order to prevent command connection timeouts. Use 0 to disable this feature.
+     * @param {string} [encoding="utf8"]  Encoding to use for control connection. UTF-8 by default. Use "latin1" for older servers.
      */
-    constructor(timeout = 0, encoding = "utf8") {
+    constructor(timeout = 0, keepAliveInterval = 0, encoding = "utf8") {
         this._timeout = timeout; // Timeout applied to all connections.
         this._task = undefined; // Current task to be resolved or rejected.
         this._handler = undefined; // Function that handles incoming messages and resolves or rejects a task.  
@@ -29,6 +30,7 @@ module.exports = class FTPContext {
         this.verbose = false; // The client can log every outgoing and incoming message.
         this.socket = new Socket(); // The control connection to the FTP server.
         this.dataSocket = undefined; // The data connection to the FTP server.
+        this._keepAliveInterval = keepAliveInterval; // The interval between NOOP commands sent to the FTP server.
     }
 
     /**
@@ -229,5 +231,10 @@ module.exports = class FTPContext {
             socket.removeAllListeners("data");
             socket.removeAllListeners("error");
         }
+    }
+
+    /** @type {number} */
+    get keepAliveInterval() {
+        return this._keepAliveInterval;
     }
 };

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -38,9 +38,10 @@ class Client {
      * Instantiate an FTP client.
      * 
      * @param {number} [timeout=30000]  Timeout in milliseconds, use 0 for no timeout.
+     * * @param {number} [keepAliveInterval=0]  The interval between NOOP commands sent to the server in order to prevent command connection timeouts. Use 0 to disable this feature.
      */
-    constructor(timeout = 30000) {
-        this.ftp = new FTPContext(timeout);
+    constructor(timeout = 30000, keepAliveInterval = 0) {
+        this.ftp = new FTPContext(timeout, keepAliveInterval);
         this.prepareTransfer = prepareTransferAutoDetect;
         this.parseList = parseListAutoDetect;
         this._progressTracker = new ProgressTracker();
@@ -707,7 +708,13 @@ function upload(ftp, progress, readableStream, remoteFilename) {
     const resolver = new TransferResolver(ftp);
     const command = "STOR " + remoteFilename;
     return ftp.handle(command, (res, task) => {
+        let interval;
         if (res.code === 150 || res.code === 125) { // Ready to upload
+            if (ftp.keepAliveInterval) {
+                interval = setInterval(() => {
+                    ftp.send("NOOP");
+                }, ftp.keepAliveInterval);
+            }
             // If we are using TLS, we have to wait until the dataSocket issued
             // 'secureConnect'. If this hasn't happened yet, getCipher() returns undefined.
             const canUpload = ftp.hasTLS === false || ftp.dataSocket.getCipher() !== undefined;
@@ -728,6 +735,9 @@ function upload(ftp, progress, readableStream, remoteFilename) {
             });
         }
         else if (positiveCompletion(res.code)) { // Transfer complete
+            if (interval) {
+                clearInterval(interval);
+            }
             resolver.resolve(task, res.code);
         }
         else if (res.code >= 400 || res.error) {


### PR DESCRIPTION
While using this library we've encountered an issue when transferring large files (5 GB+) where the control connection gets killed because it's seen as idle.
Sending NOOP commands prevents the connection from being marked as idle.
In the future it might be a good idea to add the same functionality for download as well.