### PR TITLE
add feature to change order of checking transfer strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -16,6 +16,16 @@ const fsReadDir = promisify(fs.readdir);
 const fsMkDir = promisify(fs.mkdir);
 const fsStat = promisify(fs.stat);
 
+
+const TransferStrategies = {
+    STRATEGY_IPV6: "ipv6",
+    STRATEGY_IPV4: "ipv4",
+};
+
+const strategiesMap = {};
+strategiesMap[TransferStrategies.STRATEGY_IPV4] = enterPassiveModeIPv4;
+strategiesMap[TransferStrategies.STRATEGY_IPV6] = enterPassiveModeIPv6;
+
 /**
  * @typedef {Object} PositiveResponse
  * @property {number} code  The FTP return code parsed from the FTP return message.
@@ -44,6 +54,7 @@ class Client {
         this.prepareTransfer = prepareTransferAutoDetect;
         this.parseList = parseListAutoDetect;
         this._progressTracker = new ProgressTracker();
+        this.transferStrategyOrder = [TransferStrategies.STRATEGY_IPV6, TransferStrategies.STRATEGY_IPV4];
     }
 
     /**
@@ -490,7 +501,8 @@ module.exports = {
         upgradeSocket,
         parseIPv4PasvResponse,
         TransferResolver
-    }
+    },
+    TransferStrategies
 };
 
 /**
@@ -545,6 +557,23 @@ function upgradeSocket(socket, options) {
 }
 
 /**
+ * Get order of transfer strategies iteration
+ *
+ * @param {Client} client
+ * @returns {Function[]}
+ */
+function getTransferStrategiesOrder(client) {
+    let result = [];
+    for(const strategy of client.transferStrategyOrder) {
+        if(strategiesMap.hasOwnProperty(strategy)) {
+            result.push(strategiesMap[strategy]);
+        }
+    }
+
+    return result;
+}
+
+/**
  * Try all available transfer strategies and pick the first one that works. Update `client` to
  * use the working strategy for all successive transfer requests.
  * 
@@ -553,7 +582,7 @@ function upgradeSocket(socket, options) {
  */
 async function prepareTransferAutoDetect(client) {
     client.ftp.log("Trying to find optimal transfer strategy...");
-    for (const strategy of [ enterPassiveModeIPv6, enterPassiveModeIPv4 ]) {
+    for (const strategy of getTransferStrategiesOrder(client)) {
         try {
             const res = await strategy(client);
             client.ftp.log("Optimal transfer strategy found.");


### PR DESCRIPTION
Sometimes we need to change order of iteration between strategies (f.e. because network restrictions).