### PR TITLE
chore: remove trailing whitespace & eslint enhancements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,28 +4,20 @@
         "node": true
     },
     "extends": "eslint:recommended",
-    "parserOptions": { 
+    "parserOptions": {
         "ecmaVersion": 9
-    }, 
+    },
+    "globals": {
+      "it": true,
+      "describe": true,
+      "beforeEach": true,
+      "afterEach": true
+    },
     "rules": {
-        "indent": [
-            "error",
-            4, {
-                "SwitchCase": 1
-            }
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
+        "indent": ["error", 4, {"SwitchCase": 1}],
+        "linebreak-style": ["error", "unix"],
+        "quotes": ["error", "double"],
+        "semi": ["error", "always"],
         "no-console": 0
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
         "linebreak-style": ["error", "unix"],
         "quotes": ["error", "double"],
         "semi": ["error", "always"],
-        "no-console": 0
+        "no-console": 0,
+        "no-trailing-spaces": "error"
     }
 }

--- a/lib/FileInfo.js
+++ b/lib/FileInfo.js
@@ -10,7 +10,7 @@ module.exports = class FileInfo {
             File: 0,
             Directory: 1,
             SymbolicLink: 2,
-            Unknown: 3                    
+            Unknown: 3
         };
     }
 
@@ -18,12 +18,12 @@ module.exports = class FileInfo {
         return {
             Read: 1,
             Write: 2,
-            Execute: 4        
+            Execute: 4
         };
     }
 
     /**
-     * @param {string} name 
+     * @param {string} name
      */
     constructor(name) {
         this.name = name;

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -16,17 +16,17 @@ const parseControlResponse = require("./parseControlResponse");
 /**
  * FTPContext holds the control and data sockets of an FTP connection and provides a
  * simplified way to interact with an FTP server, handle responses, errors and timeouts.
- * 
+ *
  * It doesn't implement or use any FTP commands. It's only a foundation to make writing an FTP
  * client as easy as possible. You won't usually instantiate this, but use `Client`.
  */
-module.exports = class FTPContext {  
-    
+module.exports = class FTPContext {
+
     /**
      * Instantiate an FTP context.
-     * 
+     *
      * @param {number} [timeout=0] - Timeout in milliseconds to apply to control and data connections. Use 0 for no timeout.
-     * @param {string} [encoding="utf8"] - Encoding to use for control connection. UTF-8 by default. Use "latin1" for older servers. 
+     * @param {string} [encoding="utf8"] - Encoding to use for control connection. UTF-8 by default. Use "latin1" for older servers.
      */
     constructor(timeout = 0, encoding = "utf8") {
         /**
@@ -36,9 +36,9 @@ module.exports = class FTPContext {
          */
         this._timeout = timeout;
         /**
-         * Current task to be resolved or rejected. 
+         * Current task to be resolved or rejected.
          * @private
-         * @type {(Task | undefined)} 
+         * @type {(Task | undefined)}
          */
         this._task = undefined;
         /**
@@ -66,12 +66,12 @@ module.exports = class FTPContext {
         /**
          * IP version to prefer (4: IPv4, 6: IPv6).
          * @type {(string | undefined)}
-         */ 
+         */
         this.ipFamily = undefined;
         /**
          * Log every communication detail.
          * @type {boolean}
-         */          
+         */
         this.verbose = false;
         /**
          * The control connection to the FTP server.
@@ -102,7 +102,7 @@ module.exports = class FTPContext {
      * Set the socket for the control connection. This will only close the current control socket
      * if the new one is set to `undefined` because you're most likely to be upgrading an existing
      * control connection that continues to be used.
-     * 
+     *
      * @type {Socket}
      */
     set socket(socket) {
@@ -131,8 +131,8 @@ module.exports = class FTPContext {
 
     /**
      * Set the socket for the data connection. This will automatically close the former data socket.
-     * 
-     * @type {(Socket | undefined)} 
+     *
+     * @type {(Socket | undefined)}
      **/
     set dataSocket(socket) {
         this._closeSocket(this._dataSocket);
@@ -145,7 +145,7 @@ module.exports = class FTPContext {
 
     /**
      * Send an FTP command without waiting for or handling the result.
-     * 
+     *
      * @param {string} command
      */
     send(command) {
@@ -157,8 +157,8 @@ module.exports = class FTPContext {
 
     /**
      * Log message if set to be verbose.
-     * 
-     * @param {string} message 
+     *
+     * @param {string} message
      */
     log(message) {
         if (this.verbose) {
@@ -168,10 +168,10 @@ module.exports = class FTPContext {
 
     /**
      * Enable timeout on the control socket connection. Disabling it can be useful if
-     * a timeout should be caught by the current data connection instead of the 
+     * a timeout should be caught by the current data connection instead of the
      * control connection that sits idle during transfers anyway.
-     * 
-     * @param {boolean} enabled 
+     *
+     * @param {boolean} enabled
      */
     enableControlTimeout(enabled) {
         this.socket.setTimeout(enabled ? this._timeout : 0);
@@ -180,7 +180,7 @@ module.exports = class FTPContext {
     /**
      * Return true if the control socket is using TLS. This does not mean that a session
      * has already been negotiated.
-     * 
+     *
      * @returns {boolean}
      */
     get hasTLS() {
@@ -191,7 +191,7 @@ module.exports = class FTPContext {
     /**
      * Send an FTP command and handle any response until the new task is resolved. This returns a Promise that
      * will hold whatever the handler passed on when resolving/rejecting its task.
-     * 
+     *
      * @param {string} command
      * @param {ResponseHandler} handler
      * @returns {Promise<any>}
@@ -236,9 +236,9 @@ module.exports = class FTPContext {
 
     /**
      * Handle incoming data on the control socket.
-     * 
+     *
      * @private
-     * @param {Buffer} data 
+     * @param {Buffer} data
      */
     _onControlSocketData(data) {
         let response = data.toString(this.encoding).trim();
@@ -251,26 +251,26 @@ module.exports = class FTPContext {
         // Each response group is passed along individually.
         for (const message of parsed.messages) {
             const code = parseInt(message.substr(0, 3), 10);
-            this._passToHandler({ code, message });                
+            this._passToHandler({ code, message });
         }
     }
 
     /**
      * Send the current handler a response. This is usually a control socket response
      * or a socket event, like an error or timeout.
-     * 
+     *
      * @private
-     * @param {Object} response 
+     * @param {Object} response
      */
     _passToHandler(response) {
         if (this._handler) {
             this._handler(response, this._task);
-        }        
+        }
     }
 
     /**
      * Reset the state of this context.
-     * 
+     *
      * @private
      */
     _reset() {
@@ -285,9 +285,9 @@ module.exports = class FTPContext {
 
     /**
      * Send an error to the current handler and close all connections.
-     * 
+     *
      * @private
-     * @param {*} error 
+     * @param {*} error
      */
     _closeWithError(error) {
         this.log(error);
@@ -297,9 +297,9 @@ module.exports = class FTPContext {
 
     /**
      * Close a socket.
-     * 
+     *
      * @private
-     * @param {(Socket | undefined)} socket 
+     * @param {(Socket | undefined)} socket
      */
     _closeSocket(socket) {
         if (socket) {
@@ -310,10 +310,10 @@ module.exports = class FTPContext {
 
     /**
      * Setup all error handlers for a socket.
-     * 
+     *
      * @private
-     * @param {Socket} socket 
-     * @param {string} identifier 
+     * @param {Socket} socket
+     * @param {string} identifier
      */
     _setupErrorHandlers(socket, identifier) {
         socket.once("error", error => this._closeWithError({ ...error, ftpSocket: identifier }));
@@ -327,9 +327,9 @@ module.exports = class FTPContext {
 
     /**
      * Remove all default listeners for socket.
-     * 
+     *
      * @private
-     * @param {Socket} socket 
+     * @param {Socket} socket
      */
     _removeSocketListeners(socket) {
         // socket.removeAllListeners() without name doesn't work: https://github.com/nodejs/node/issues/20923

--- a/lib/ProgressTracker.js
+++ b/lib/ProgressTracker.js
@@ -24,8 +24,8 @@ module.exports = class ProgressTracker {
 
     /**
      * Register a new handler for progress info. Use `undefined` to disable reporting.
-     * 
-     * @param {((info: ProgressInfo) => void)} [handler] 
+     *
+     * @param {((info: ProgressInfo) => void)} [handler]
      */
     reportTo(handler = () => {}) {
         this._handler = handler;
@@ -33,7 +33,7 @@ module.exports = class ProgressTracker {
 
     /**
      * Start tracking transfer progress of a socket.
-     * 
+     *
      * @param {import("net").Socket} socket  The socket to observe.
      * @param {string} name  A name associated with this progress tracking, e.g. a filename.
      * @param {string} type  The type of the transfer, typically "upload" or "download".
@@ -49,7 +49,7 @@ module.exports = class ProgressTracker {
                 type,
                 bytes,
                 bytesOverall: this.bytesOverall
-            }); 
+            });
         });
     }
 
@@ -71,8 +71,8 @@ module.exports = class ProgressTracker {
 /**
  * Starts calling a callback function at a regular interval. The first call will go out
  * immediately. The function returns a function to stop the polling.
- * 
- * @param {number} intervalMillis 
+ *
+ * @param {number} intervalMillis
  * @param {(() => any)} cb
  * @returns {((stopWithUpdate: boolean) => void)}
  */

--- a/lib/StringWriter.js
+++ b/lib/StringWriter.js
@@ -6,7 +6,7 @@ const EventEmitter = require("events");
  * Collect binary data chunks as a string.
  */
 module.exports = class StringWriter extends EventEmitter {
-    
+
     constructor(encoding) {
         super();
         this.encoding = encoding;

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -25,7 +25,7 @@ const fsStat = promisify(fs.stat);
 /**
  * @typedef {Object} NegativeResponse
  * @property {Object|string} error  The error description.
- * 
+ *
  * Negative responses are usually thrown as exceptions, not returned as values.
  */
 
@@ -33,10 +33,10 @@ const fsStat = promisify(fs.stat);
  * Client offers an API to interact with an FTP server.
  */
 class Client {
-    
+
     /**
      * Instantiate an FTP client.
-     * 
+     *
      * @param {number} [timeout=30000]  Timeout in milliseconds, use 0 for no timeout.
      */
     constructor(timeout = 30000) {
@@ -56,16 +56,16 @@ class Client {
 
     /**
      * Connect to an FTP server.
-     * 
+     *
      * @param {string} [host=localhost]  Host the client should connect to.
      * @param {number} [port=21]  Port the client should connect to.
      * @returns {Promise<PositiveResponse>}
      */
     connect(host = "localhost", port = 21) {
-        this.ftp.socket.connect({ 
-            host, 
-            port, 
-            family: this.ftp.ipFamily 
+        this.ftp.socket.connect({
+            host,
+            port,
+            family: this.ftp.ipFamily
         }, () => this.ftp.log(`Connected to ${describeAddress(this.ftp.socket)}`));
         return this.ftp.handle(undefined, (res, task) => {
             if (positiveCompletion(res.code)) {
@@ -80,11 +80,11 @@ class Client {
 
     /**
      * Send an FTP command.
-     * 
-     * If successful it will return a response object that contains the return code as well 
-     * as the whole message. Ignore FTP error codes if you don't want an exception to be thrown 
+     *
+     * If successful it will return a response object that contains the return code as well
+     * as the whole message. Ignore FTP error codes if you don't want an exception to be thrown
      * if an FTP command didn't succeed.
-     * 
+     *
      * @param {string} command  FTP command to send.
      * @param {boolean} [ignoreErrorCodes=false]  Whether to ignore FTP error codes in result.
      * @returns {Promise<PositiveResponse>}
@@ -103,7 +103,7 @@ class Client {
 
     /**
      * Upgrade the current socket connection to TLS.
-     * 
+     *
      * @param {tls.ConnectionOptions} [options={}]  TLS options as in `tls.connect(options)`
      * @param {string} [command="AUTH TLS"]  Set the authentication command, e.g. "AUTH SSL" instead of "AUTH TLS".
      * @returns {Promise<PositiveResponse>}
@@ -112,13 +112,13 @@ class Client {
         const ret = await this.send(command);
         this.ftp.socket = await upgradeSocket(this.ftp.socket, options);
         this.ftp.tlsOptions = options; // Keep the TLS options for later data connections that should use the same options.
-        this.ftp.log(`Control socket is using: ${describeTLS(this.ftp.socket)}`);        
+        this.ftp.log(`Control socket is using: ${describeTLS(this.ftp.socket)}`);
         return ret;
     }
 
     /**
      * Login a user with a password.
-     * 
+     *
      * @param {string} [user="anonymous"]  Username to use for login.
      * @param {string} [password="guest"]  Password to use for login.
      * @returns {Promise<PositiveResponse>}
@@ -140,12 +140,12 @@ class Client {
 
     /**
      * Set the usual default settings.
-     * 
+     *
      * Settings used:
      * * Binary mode (TYPE I)
      * * File structure (STRU F)
      * * Additional settings for FTPS (PBSZ 0, PROT P)
-     * 
+     *
      * @returns {Promise<void>}
      */
     async useDefaultSettings() {
@@ -159,7 +159,7 @@ class Client {
 
     /**
      * Convenience method that calls `connect`, `useTLS`, `login` and `useDefaultSettings`.
-     * 
+     *
      * @typedef {Object} AccessOptions
      * @property {string} [host]  Host the client should connect to.
      * @property {number} [port]  Port the client should connect to.
@@ -182,9 +182,9 @@ class Client {
 
     /**
      * Set the working directory.
-     * 
+     *
      * @param {string} path
-     * @returns {Promise<PositiveResponse>} 
+     * @returns {Promise<PositiveResponse>}
      */
     cd(path) {
         return this.send("CWD " + path);
@@ -192,19 +192,19 @@ class Client {
 
     /**
      * Get the current working directory.
-     * 
+     *
      * @returns {Promise<string>}
      */
     async pwd() {
         const res = await this.send("PWD");
-        // The directory is part of the return message, for example: 
+        // The directory is part of the return message, for example:
         // 257 "/this/that" is current directory.
         return res.message.match(/"(.+)"/)[1];
     }
 
     /**
      * Get the last modified time of a file. Not supported by every FTP server, method might throw exception.
-     * 
+     *
      * @param {string} filename  Name of the file in the current working directory.
      * @returns {Promise<Date>}
      */
@@ -222,11 +222,11 @@ class Client {
 
     /**
      * Get a description of supported features.
-     * 
+     *
      * This sends the FEAT command and parses the result into a Map where keys correspond to available commands
      * and values hold further information. Be aware that your FTP servers might not support this
      * command in which case this method will not throw an exception but just return an empty Map.
-     * 
+     *
      * @returns {Promise<Map<string, string>>} a Map, keys hold commands and values further options.
      */
     async features() {
@@ -236,7 +236,7 @@ class Client {
         if (res.code < 400 && isMultiline(res.message)) {
             // The first and last line wrap the multiline response, ignore them.
             res.message.split("\n").slice(1, -1).forEach(line => {
-                // A typical lines looks like: " REST STREAM" or " MDTM". 
+                // A typical lines looks like: " REST STREAM" or " MDTM".
                 // Servers might not use an indentation though.
                 const entry = line.trim().split(" ");
                 features.set(entry[0], entry[1] || "");
@@ -247,7 +247,7 @@ class Client {
 
     /**
      * Get the size of a file.
-     * 
+     *
      * @param {string} filename  Name of the file in the current working directory.
      * @returns {Promise<number>}
      */
@@ -259,13 +259,13 @@ class Client {
     }
 
     /**
-     * Rename a file. 
-     * 
-     * Depending on the FTP server this might also be used to move a file from one 
+     * Rename a file.
+     *
+     * Depending on the FTP server this might also be used to move a file from one
      * directory to another by providing full paths.
-     * 
-     * @param {string} path 
-     * @param {string} newPath 
+     *
+     * @param {string} path
+     * @param {string} newPath
      * @returns {Promise<PositiveResponse>} response of second command (RNTO)
      */
     async rename(path, newPath) {
@@ -275,10 +275,10 @@ class Client {
 
     /**
      * Remove a file from the current working directory.
-     * 
+     *
      * You can ignore FTP error return codes which won't throw an exception if e.g.
      * the file doesn't exist.
-     * 
+     *
      * @param {string} filename  Name of the file to remove.
      * @param {boolean} [ignoreErrorCodes=false]  Ignore error return codes.
      * @returns {Promise<PositiveResponse>}
@@ -289,10 +289,10 @@ class Client {
 
     /**
      * Report transfer progress for any upload or download to a given handler.
-     * 
+     *
      * This will also reset the overall transfer counter that can be used for multiple transfers. You can
      * also pass `undefined` as a handler to stop reporting to an earlier one.
-     * 
+     *
      * @param {((info: import("./ProgressTracker").ProgressInfo) => void)} [handler=undefined]  Handler function to call on transfer progress.
      */
     trackProgress(handler) {
@@ -301,8 +301,8 @@ class Client {
     }
 
     /**
-     * Upload data from a readable stream and store it as a file with a given filename in the current working directory. 
-     * 
+     * Upload data from a readable stream and store it as a file with a given filename in the current working directory.
+     *
      * @param {import("stream").Readable} readableStream  The stream to read from.
      * @param {string} remoteFilename  The filename of the remote file to write to.
      * @returns {Promise<PositiveResponse>}
@@ -313,10 +313,10 @@ class Client {
     }
 
     /**
-     * Download a file with a given filename from the current working directory 
-     * and pipe its data to a writable stream. You may optionally start at a specific 
+     * Download a file with a given filename from the current working directory
+     * and pipe its data to a writable stream. You may optionally start at a specific
      * offset, for example to resume a cancelled transfer.
-     * 
+     *
      * @param {import("stream").Writable} writableStream  The stream to write to.
      * @param {string} remoteFilename  The name of the remote file to read from.
      * @param {number} [startAt=0]  The offset to start at.
@@ -330,7 +330,7 @@ class Client {
 
     /**
      * List files and directories in the current working directory.
-     * 
+     *
      * @returns {Promise<FileInfo[]>}
      */
     async list() {
@@ -338,17 +338,17 @@ class Client {
         const writable = new StringWriter(this.ftp.encoding);
         const progressTracker = nullObject(); // Don't track progress of list transfers.
         //@ts-ignore that progressTracker is not really of type ProgressTracker.
-        await download(this.ftp, progressTracker, writable, "LIST -a"); 
+        await download(this.ftp, progressTracker, writable, "LIST -a");
         this.ftp.log(writable.text);
         return this.parseList(writable.text);
     }
 
     /**
      * Remove a directory and all of its content.
-     * 
+     *
      * After successfull completion the current working directory will be the parent
      * of the removed directory if possible.
-     * 
+     *
      * @param {string} remoteDirPath  The path of the remote directory to delete.
      * @example client.removeDir("foo") // Remove directory 'foo' using a relative path.
      * @example client.removeDir("foo/bar") // Remove directory 'bar' using a relative path.
@@ -363,14 +363,14 @@ class Client {
         const workingDir = await this.pwd();
         if (workingDir !== "/") {
             await this.send("CDUP");
-            await this.send("RMD " + remoteDirPath);        
+            await this.send("RMD " + remoteDirPath);
         }
     }
 
     /**
      * Remove all files and directories in the working directory without removing
      * the working directory itself.
-     * 
+     *
      * @returns {Promise<void>}
      */
     async clearWorkingDir() {
@@ -388,12 +388,12 @@ class Client {
     }
 
     /**
-     * Upload the contents of a local directory to the working directory. 
-     * 
-     * You can optionally provide a `remoteDirName` to put the contents inside a directory which 
-     * will be created if necessary. This will overwrite existing files with the same names and 
+     * Upload the contents of a local directory to the working directory.
+     *
+     * You can optionally provide a `remoteDirName` to put the contents inside a directory which
+     * will be created if necessary. This will overwrite existing files with the same names and
      * reuse existing directories. Unrelated files and directories will remain untouched.
-     * 
+     *
      * @param {string} localDirPath  A local path, e.g. "foo/bar" or "../test"
      * @param {string} [remoteDirName]  The name of the remote directory. If undefined, directory contents will be uploaded to the working directory.
      * @returns {Promise<void>}
@@ -415,7 +415,7 @@ class Client {
 
     /**
      * Download all files and directories of the working directory to a local directory.
-     * 
+     *
      * @param {string} localDirPath  The local directory to download to.
      * @returns {Promise<void>}
      */
@@ -438,8 +438,8 @@ class Client {
     /**
      * Make sure a given remote path exists, creating all directories as necessary.
      * This function also changes the current working directory to the given path.
-     * 
-     * @param {string} remoteDirPath 
+     *
+     * @param {string} remoteDirPath
      * @returns {Promise<void>}
      */
     async ensureDir(remoteDirPath) {
@@ -456,17 +456,17 @@ class Client {
 
 /**
  * Resolves a given task if one party has provided a result and another one confirmed it.
- * 
- * This is used internally for all FTP transfers. For example when downloading, the server might confirm 
- * with "226 Transfer complete" when in fact the download on the data connection has not finished 
- * yet. With all transfers we make sure that a) the result arrived and b) has been confirmed by 
+ *
+ * This is used internally for all FTP transfers. For example when downloading, the server might confirm
+ * with "226 Transfer complete" when in fact the download on the data connection has not finished
+ * yet. With all transfers we make sure that a) the result arrived and b) has been confirmed by
  * e.g. the control connection. We just don't know in which order this will happen.
  */
 class TransferResolver {
-    
+
     /**
      * Instantiate a TransferResolver
-     * @param {FTPContext} ftp 
+     * @param {FTPContext} ftp
      */
     constructor(ftp) {
         this.ftp = ftp;
@@ -492,7 +492,7 @@ class TransferResolver {
     _tryResolve(task) {
         if (this.confirmed && this.result !== undefined) {
             this.ftp.dataSocket = undefined;
-            task.resolve(this.result);    
+            task.resolve(this.result);
         }
     }
 }
@@ -515,8 +515,8 @@ module.exports = {
 /**
  * Return true if an FTP return code describes a positive completion. Often it's not
  * necessary to know which code it was specifically.
- * 
- * @param {number} code 
+ *
+ * @param {number} code
  * @returns {boolean}
  */
 function positiveCompletion(code) {
@@ -525,8 +525,8 @@ function positiveCompletion(code) {
 
 /**
  * Returns true if an FTP response line is the beginning of a multiline response.
- * 
- * @param {string} line 
+ *
+ * @param {string} line
  * @returns {boolean}
  */
 function isMultiline(line) {
@@ -535,9 +535,9 @@ function isMultiline(line) {
 
 /**
  * Returns a string describing the encryption on a given socket instance.
- * 
+ *
  * @param {(net.Socket | tls.TLSSocket)} socket
- * @returns {string} 
+ * @returns {string}
  */
 function describeTLS(socket) {
     if (socket instanceof tls.TLSSocket) {
@@ -548,8 +548,8 @@ function describeTLS(socket) {
 
 /**
  * Returns a string describing the remote address of a socket.
- * 
- * @param {net.Socket} socket 
+ *
+ * @param {net.Socket} socket
  * @returns {string}
  */
 function describeAddress(socket) {
@@ -561,16 +561,16 @@ function describeAddress(socket) {
 
 /**
  * Upgrade a socket connection with TLS.
- * 
- * @param {net.Socket} socket 
+ *
+ * @param {net.Socket} socket
  * @param {tls.ConnectionOptions} options Same options as in `tls.connect(options)`
  * @returns {Promise<tls.TLSSocket>}
  */
 function upgradeSocket(socket, options) {
     return new Promise((resolve, reject) => {
-        const tlsOptions = Object.assign({}, options, { 
+        const tlsOptions = Object.assign({}, options, {
             socket // Establish the secure connection using an existing socket connection.
-        }); 
+        });
         const tlsSocket = tls.connect(tlsOptions, () => {
             // Make sure the certificate is valid if an unauthorized one should be rejected.
             const expectCertificate = tlsOptions.rejectUnauthorized !== false;
@@ -584,14 +584,14 @@ function upgradeSocket(socket, options) {
             }
         }).once("error", error => {
             reject(error);
-        });                
+        });
     });
 }
 
 /**
  * Try all available transfer strategies and pick the first one that works. Update `client` to
  * use the working strategy for all successive transfer requests.
- * 
+ *
  * @param {((client: Client)=>Promise<PositiveResponse>)[]} strategies
  * @returns {(client: Client)=>Promise<PositiveResponse>} a function that will try the provided strategies.
  */
@@ -612,12 +612,12 @@ function enterFirstCompatibleMode(...strategies) {
             }
         }
         throw new Error("None of the available transfer strategies work.");
-    };    
+    };
 }
 
 /**
  * Prepare a data socket using passive mode over IPv6.
- * 
+ *
  * @param {Client} client
  * @returns {Promise<PositiveResponse>}
  */
@@ -634,7 +634,7 @@ async function enterPassiveModeIPv6(client) {
 
 /**
  * Parse an EPSV response. Returns only the port as in EPSV the host of the control connection is used.
- * 
+ *
  * @param {string} message
  * @returns {number} port
  */
@@ -646,7 +646,7 @@ function parseIPv6PasvResponse(message) {
 
 /**
  * Prepare a data socket using passive mode over IPv4.
- * 
+ *
  * @param {Client} client
  * @returns {Promise<PositiveResponse>}
  */
@@ -669,7 +669,7 @@ async function enterPassiveModeIPv4(client) {
 
 /**
  * Parse a PASV response.
- * 
+ *
  * @param {string} message
  * @returns {{host: string, port: number}}
  */
@@ -688,7 +688,7 @@ function parseIPv4PasvResponse(message) {
 /**
  * Returns true if an IP is a private address according to https://tools.ietf.org/html/rfc1918#section-3.
  * This will handle IPv4-mapped IPv6 addresses correctly but return false for all other IPv6 addresses.
- * 
+ *
  * @param {string} ip  The IP as a string, e.g. "192.168.0.1"
  * @returns {boolean} true if the ip is local.
  */
@@ -728,28 +728,28 @@ function connectForPassiveTransfer(host, port, ftp) {
                 // specific transfer request has been made. List and download don't
                 // have to wait for this event because the server sends whenever it
                 // is ready. But for upload this has to be taken into account,
-                // see the details in the upload() function below. 
+                // see the details in the upload() function below.
             }
             // Let the FTPContext listen to errors from now on, remove local handler.
             socket.removeListener("error", handleConnErr);
             ftp.dataSocket = socket;
             resolve();
-        });                   
+        });
     });
 }
 
 /**
  * Upload stream data as a file. For example:
- * 
+ *
  * `upload(ftp, fs.createReadStream(localFilePath), remoteFilename)`
- * 
- * @param {FTPContext} ftp 
+ *
+ * @param {FTPContext} ftp
  * @param {ProgressTracker} progress
- * @param {import("stream").Readable} readableStream 
- * @param {string} remoteFilename 
+ * @param {import("stream").Readable} readableStream
+ * @param {string} remoteFilename
  * @returns {Promise<PositiveResponse>}
  */
-function upload(ftp, progress, readableStream, remoteFilename) {  
+function upload(ftp, progress, readableStream, remoteFilename) {
     const resolver = new TransferResolver(ftp);
     const command = "STOR " + remoteFilename;
     return ftp.handle(command, (res, task) => {
@@ -768,17 +768,17 @@ function upload(ftp, progress, readableStream, remoteFilename) {
                 progress.start(ftp.dataSocket, remoteFilename, "upload");
                 readableStream.pipe(ftp.dataSocket).once("finish", () => {
                     ftp.dataSocket.destroy(); // Explicitly close/destroy the socket to signal the end.
-                    ftp.enableControlTimeout(true);                    
+                    ftp.enableControlTimeout(true);
                     progress.updateAndStop();
-                    resolver.confirm(task);             
-                });                                
+                    resolver.confirm(task);
+                });
             });
         }
         else if (positiveCompletion(res.code)) { // Transfer complete
             resolver.resolve(task, res.code);
         }
         else if (res.code >= 400 || res.error) {
-            ftp.enableControlTimeout(true);            
+            ftp.enableControlTimeout(true);
             progress.updateAndStop();
             resolver.reject(task, res);
         }
@@ -787,11 +787,11 @@ function upload(ftp, progress, readableStream, remoteFilename) {
 
 /**
  * Download data from the data connection. Used for downloading files and directory listings.
- * 
- * @param {FTPContext} ftp 
+ *
+ * @param {FTPContext} ftp
  * @param {ProgressTracker} progress
- * @param {import("stream").Writable} writableStream 
- * @param {string} command 
+ * @param {import("stream").Writable} writableStream
+ * @param {string} command
  * @param {string} [remoteFilename]
  * @returns {Promise<PositiveResponse>}
  */
@@ -833,7 +833,7 @@ function download(ftp, progress, writableStream, command, remoteFilename = "") {
 /**
  * Calls a function immediately if a condition is met or subscribes to an event and calls
  * it once the event is emitted.
- * 
+ *
  * @param {boolean} condition  The condition to test.
  * @param {*} emitter  The emitter to use if the condition is not met.
  * @param {string} eventName  The event to subscribe to if the condition is not met.
@@ -851,8 +851,8 @@ function conditionOrEvent(condition, emitter, eventName, action) {
 /**
  * Upload the contents of a local directory to the working directory. This will overwrite
  * existing files and reuse existing directories.
- * 
- * @param {string} localDirPath 
+ *
+ * @param {string} localDirPath
  */
 async function uploadDirContents(client, localDirPath) {
     const files = await fsReadDir(localDirPath);
@@ -865,7 +865,7 @@ async function uploadDirContents(client, localDirPath) {
         else if (stats.isDirectory()) {
             await openDir(client, file);
             await uploadDirContents(client, fullPath);
-            await client.send("CDUP"); 
+            await client.send("CDUP");
         }
     }
 }
@@ -873,9 +873,9 @@ async function uploadDirContents(client, localDirPath) {
 /**
  * Try to create a directory and enter it. This will not raise an exception if the directory
  * couldn't be created if for example it already exists.
- * 
- * @param {Client} client 
- * @param {string} dirName 
+ *
+ * @param {Client} client
+ * @param {string} dirName
  */
 async function openDir(client, dirName) {
     await client.send("MKD " + dirName, true); // Ignore FTP error codes
@@ -888,5 +888,5 @@ async function ensureLocalDirectory(path) {
     }
     catch(err) {
         await fsMkDir(path);
-    }    
+    }
 }

--- a/lib/nullObject.js
+++ b/lib/nullObject.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Get an object that will let you call any method by any name. These methods won't 
+ * Get an object that will let you call any method by any name. These methods won't
  * do anything and will always return `undefined`.
  */
 module.exports = () => new Proxy({}, {

--- a/lib/parseControlResponse.js
+++ b/lib/parseControlResponse.js
@@ -3,14 +3,14 @@
 const LF = "\n";
 
 /**
- * Parse an FTP control response as a collection of messages. A message is a complete 
- * single- or multiline response. A response can also contain multiple multiline responses 
- * that will each be represented by a message. A response can also be incomplete 
- * and be completed on the next incoming data chunk for which case this function also 
+ * Parse an FTP control response as a collection of messages. A message is a complete
+ * single- or multiline response. A response can also contain multiple multiline responses
+ * that will each be represented by a message. A response can also be incomplete
+ * and be completed on the next incoming data chunk for which case this function also
  * describes a `rest`. This function converts all CRLF to LF.
- * 
- * @param {string} text 
- * @returns {{messages: string[], rest: string}} 
+ *
+ * @param {string} text
+ * @returns {{messages: string[], rest: string}}
  */
 module.exports = function parseControlResponse(text) {
     const lines = text.split(/\r?\n/);
@@ -24,7 +24,7 @@ module.exports = function parseControlResponse(text) {
             if (isMultiline(line)) {
                 // Open a group by setting an expected token.
                 token = line.substr(0, 3) + " ";
-                startAt = i;                    
+                startAt = i;
             }
             else if (isSingle(line)) {
                 // Single lines can be grouped immediately.
@@ -39,7 +39,7 @@ module.exports = function parseControlResponse(text) {
     }
     // The last group might not have been closed, report it as a rest.
     const rest = token !== "" ? lines.slice(startAt).join(LF) + LF : "";
-    return { messages, rest };      
+    return { messages, rest };
 };
 
 function isSingle(line) {

--- a/lib/parseList.js
+++ b/lib/parseList.js
@@ -7,9 +7,9 @@ const availableParsers = [
 
 /**
  * Parse raw list data.
- * 
+ *
  * @param {string} rawList
- * @returns {import("./FileInfo")[]} 
+ * @returns {import("./FileInfo")[]}
  */
 module.exports = function parseList(rawList) {
     const lines = rawList.split(/\r?\n/)

--- a/lib/parseListDOS.js
+++ b/lib/parseListDOS.js
@@ -5,8 +5,8 @@ const FileInfo = require("./FileInfo");
 /**
  * This parser is based on the FTP client library source code in Apache Commons Net provided
  * under the Apache 2.0 license. It has been simplified and rewritten to better fit the Javascript language.
- * 
- * http://svn.apache.org/viewvc/commons/proper/net/tags/NET_3_6/src/main/java/org/apache/commons/net/ftp/parser/NTFTPEntryParser.java?revision=1783048&view=markup 
+ *
+ * http://svn.apache.org/viewvc/commons/proper/net/tags/NET_3_6/src/main/java/org/apache/commons/net/ftp/parser/NTFTPEntryParser.java?revision=1783048&view=markup
  */
 
 const RE_LINE = new RegExp(

--- a/lib/parseListUnix.js
+++ b/lib/parseListUnix.js
@@ -5,7 +5,7 @@ const FileInfo = require("./FileInfo");
 /**
  * This parser is based on the FTP client library source code in Apache Commons Net provided
  * under the Apache 2.0 license. It has been simplified and rewritten to better fit the Javascript language.
- * 
+ *
  * http://svn.apache.org/viewvc/commons/proper/net/tags/NET_3_6/src/main/java/org/apache/commons/net/ftp/parser/
  *
  * Below is the regular expression used by this parser.
@@ -90,14 +90,14 @@ exports.parseLine = function(line) {
             return undefined;
         }
 
-        // Map list entry to FileInfo instance        
+        // Map list entry to FileInfo instance
         const file = new FileInfo(name);
         file.size = parseInt(groups[18], 10);
         file.user = groups[16];
         file.group = groups[17];
         file.hardLinkCount = parseInt(groups[15], 10);
         file.date = groups[19] + " " + groups[20];
-        
+
         // Set file type
         switch (groups[1].charAt(0)) {
             case "d":
@@ -137,7 +137,7 @@ exports.parseLine = function(line) {
             if (execToken !== "-" && execToken.toUpperCase() !== execToken) {
                 value += FileInfo.Permission.Execute;
             }
-            file.permissions[access] = value; 
+            file.permissions[access] = value;
         });
 
         // Separate out the link name for symbolic links

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FTP client for Node.js with support for explicit FTPS over TLS.",
   "main": "./lib/ftp",
   "scripts": {
-    "test": "mocha",
+    "test": "eslint . && mocha",
     "tdd": "mocha --watch",
     "lint": "eslint lib/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "eslint . && mocha",
     "tdd": "mocha --watch",
-    "lint": "eslint lib/*.js"
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/test/SocketMock.js
+++ b/test/SocketMock.js
@@ -26,4 +26,4 @@ module.exports = class SocketMock extends EventEmitter {
     pipe(target) {
         this.on("data", chunk => target.write(chunk));
     }
-}
+};

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -34,7 +34,7 @@ describe("Convenience API", function() {
         client.close();
     });
 
-    /** 
+    /**
      * Testing simple convenience functions follows the same pattern:
      * 1. Call some method on client (func)
      * 2. This makes client send an FTP command (command)
@@ -82,21 +82,21 @@ describe("Convenience API", function() {
             func: c => c.send("TEST"),
             command: "TEST\r\n",
             reply: "200 Ok\r\n",
-            result: { code: 200, message: '200 Ok' }
+            result: { code: 200, message: "200 Ok" }
         },
         {
             name: "send command: can handle error",
             func: c => c.send("TEST"),
             command: "TEST\r\n",
             reply: "500 Error\r\n",
-            result: new MockError({ code: 500, message: '500 Error' })
+            result: new MockError({ code: 500, message: "500 Error" })
         },
         {
             name: "send command: can optionally ignore error response (>=400)",
             func: c => c.send("TEST", true),
             command: "TEST\r\n",
             reply: "400 Error\r\n",
-            result: { code: 400, message: '400 Error' }
+            result: { code: 400, message: "400 Error" }
         },
         {
             name: "send command: ignoring error responses still throws error for connection errors",
@@ -109,7 +109,7 @@ describe("Convenience API", function() {
             name: "can get the working directory",
             func: c => c.pwd(),
             command: "PWD\r\n",
-            reply: `257 "/this/that" is current directory.\r\n`,
+            reply: "257 \"/this/that\" is current directory.\r\n",
             result: "/this/that"
         },
         {
@@ -125,27 +125,27 @@ describe("Convenience API", function() {
             command: "DELE foo.txt\r\n",
             reply: "250 Okay",
             result: { code: 250, message: "250 Okay" }
-        },             
+        },
     ];
 
     tests.forEach(test => {
-        it(test.name, function() {               
+        it(test.name, function() {
             client.ftp.socket.once("didSend", buf => {
                 assert.equal(buf.toString(), test.command);
                 if (test.reply) {
                     client.ftp.socket.emit("data", Buffer.from(test.reply));
                 }
                 else {
-                    client.ftp.socket.emit("error", { info: "SocketError" })
+                    client.ftp.socket.emit("error", { info: "SocketError" });
                 }
-             });
+            });
             const promise = test.func(client);
             if (test.result instanceof MockError) {
                 return promise.catch(err => assert.deepEqual(err, test.result.info));
             }
             else {
                 return promise.then(result => assert.deepEqual(result, test.result));
-            }               
+            }
         });
     });
 
@@ -160,14 +160,14 @@ describe("Convenience API", function() {
             assert.equal(options.host, "host");
             assert.equal(options.port, 22, "Socket port");
             setTimeout(() => client.ftp.socket.emit("data", Buffer.from("200 OK")));
-        }
+        };
         return client.connect("host", 22).then(result => assert.deepEqual(result, { code: 200, message: "200 OK"}));
     });
 
     it("declines connect for code 120", function() {
         client.ftp.socket.connect = () => {
             setTimeout(() => client.ftp.socket.emit("data", Buffer.from("120 Ready in 5 hours")));
-        }
+        };
         return client.connect("host", 22).catch(result => assert.deepEqual(result, { code: 120, message: "120 Ready in 5 hours"}));
     });
 
@@ -181,14 +181,14 @@ describe("Convenience API", function() {
             }
             else if (step === 2) {
                 assert.equal(buf.toString().trim(), "PASS pass");
-                client.ftp.socket.emit("data", Buffer.from("200 OK"));                
+                client.ftp.socket.emit("data", Buffer.from("200 OK"));
             }
         });
         return client.login("user", "pass").then(result => assert.deepEqual(result, { code: 200, message: "200 OK" }));
     });
 
     it("declines login on '332 Account needed'", function() {
-        client.ftp.socket.once("didSend", buf => {
+        client.ftp.socket.once("didSend", () => {
             client.ftp.socket.emit("data", Buffer.from("332 Account needed"));
         });
         return client.login("user", "pass").catch(result => assert.deepEqual(result, { code: 332, message: "332 Account needed" }));

--- a/test/downloadSpec.js
+++ b/test/downloadSpec.js
@@ -12,13 +12,13 @@ describe("Download directory listing", function() {
     var f;
     const bufList = Buffer.from("12-05-96  05:03PM       <DIR>          myDir");
     const expList = [
-        (f = new FileInfo("myDir"), 
+        (f = new FileInfo("myDir"),
         f.size = 0,
         f.date = "12-05-96 05:03PM",
-        f.type = FileInfo.Type.Directory, 
+        f.type = FileInfo.Type.Directory,
         f)
     ];
- 
+
     let client;
     beforeEach(function() {
         client = new Client();
@@ -37,7 +37,7 @@ describe("Download directory listing", function() {
         client.list().then(result => {
             assert.deepEqual(result, expList);
             done();
-        });        
+        });
     }
 
     it("sends the right command", function(done) {
@@ -54,7 +54,7 @@ describe("Download directory listing", function() {
             client.ftp.socket.emit("data", Buffer.from("125 Sending"));
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
-            client.ftp.socket.emit("data", Buffer.from("250 Done"));    
+            client.ftp.socket.emit("data", Buffer.from("250 Done"));
         });
     });
 
@@ -62,7 +62,7 @@ describe("Download directory listing", function() {
         requestListAndVerify(done);
         setTimeout(() => {
             client.ftp.socket.emit("data", Buffer.from("125 Sending"));
-            client.ftp.socket.emit("data", Buffer.from("250 Done"));    
+            client.ftp.socket.emit("data", Buffer.from("250 Done"));
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
         });
@@ -74,8 +74,8 @@ describe("Download directory listing", function() {
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.socket.emit("data", Buffer.from("125 Sending"));
             client.ftp.dataSocket.end();
-            client.ftp.socket.emit("data", Buffer.from("250 Done"));    
-        });     
+            client.ftp.socket.emit("data", Buffer.from("250 Done"));
+        });
     });
 
     it("handles data transmission being complete before control announces beginning", function(done) {
@@ -84,8 +84,8 @@ describe("Download directory listing", function() {
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
             client.ftp.socket.emit("data", Buffer.from("125 Sending"));
-            client.ftp.socket.emit("data", Buffer.from("250 Done"));    
-        });     
+            client.ftp.socket.emit("data", Buffer.from("250 Done"));
+        });
     });
 
     it("handles control announcing with 150 instead of 125", function(done) {
@@ -94,7 +94,7 @@ describe("Download directory listing", function() {
             client.ftp.socket.emit("data", Buffer.from("150 Sending"));
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
-            client.ftp.socket.emit("data", Buffer.from("250 Done"));    
+            client.ftp.socket.emit("data", Buffer.from("250 Done"));
         });
     });
 
@@ -104,7 +104,7 @@ describe("Download directory listing", function() {
             client.ftp.socket.emit("data", Buffer.from("125 Sending"));
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
-            client.ftp.socket.emit("data", Buffer.from("200 Done"));    
+            client.ftp.socket.emit("data", Buffer.from("200 Done"));
         });
     });
 

--- a/test/fileInfoSpec.js
+++ b/test/fileInfoSpec.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const FileInfo = require("../lib/FileInfo");
 
 describe("FileInfo", function() {
-    
+
     it("can report type of file", function() {
         const f = new FileInfo("");
         f.type = FileInfo.Type.File;
@@ -18,6 +18,6 @@ describe("FileInfo", function() {
     it("can report type of symbolic link", function() {
         const f = new FileInfo("");
         f.type = FileInfo.Type.SymbolicLink;
-        assert(f.isSymbolicLink); 
+        assert(f.isSymbolicLink);
     });
 });

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -16,13 +16,13 @@ describe("FTPContext", function() {
     it("Setting new control socket doesn't destroy current", function() {
         const old = ftp.socket;
         ftp.socket = new SocketMock();
-        assert.equal(old.destroyed, false, "Socket not destroyed.");                
+        assert.equal(old.destroyed, false, "Socket not destroyed.");
     });
 
     it("Setting control socket to undefined destroys current", function() {
         const old = ftp.socket;
         ftp.socket = undefined;
-        assert.equal(old.destroyed, true, "Socket destroyed.");                
+        assert.equal(old.destroyed, true, "Socket destroyed.");
     });
 
     it("Setting new data socket destroys current", function() {
@@ -32,7 +32,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays control socket timeout event", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { error: { info: "socket timeout", ftpSocket: "control" }});
             done();
         });
@@ -40,7 +40,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays control socket error event", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { error: { foo: "bar", ftpSocket: "control" } });
             done();
         });
@@ -48,7 +48,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays data socket timeout event", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { error: { info: "socket timeout", ftpSocket: "data" }});
             done();
         });
@@ -56,7 +56,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays data socket error event", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { error: { foo: "bar", ftpSocket: "data" } });
             done();
         });
@@ -64,7 +64,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays single line control response", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { code: 200, message: "200 OK"});
             done();
         });
@@ -72,7 +72,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays multiline control response", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { code: 200, message: "200-OK\nHello\n200 OK"});
             done();
         });
@@ -81,7 +81,7 @@ describe("FTPContext", function() {
 
     it("Relays multiple multiline control responses in separate callbacks", function(done) {
         const exp = new Set(["200-OK\n200 OK", "200-Again\n200 Again" ]);
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.equal(true, exp.has(res.message));
             exp.delete(res.message);
             if (exp.size === 0) {
@@ -92,12 +92,12 @@ describe("FTPContext", function() {
     });
 
     it("Relays chunked multiline response as a single response", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, res => {
             assert.deepEqual(res, { code: 200, message: "200-OK\nHello\n200 OK"});
             done();
         });
-        ftp.socket.emit("data", Buffer.from("200-OK\r\n"));     
-        ftp.socket.emit("data", Buffer.from("Hello\r\n200 OK")); 
+        ftp.socket.emit("data", Buffer.from("200-OK\r\n"));
+        ftp.socket.emit("data", Buffer.from("Hello\r\n200 OK"));
     });
 
     it("Stops relaying if task is resolved", function(done) {
@@ -110,7 +110,7 @@ describe("FTPContext", function() {
             ftp.socket.emit("data", Buffer.from("220 Done"));
             done();
         });
-        ftp.socket.emit("data", Buffer.from("200 OK"));  
+        ftp.socket.emit("data", Buffer.from("200 OK"));
     });
 
     it("can send a command", function(done) {
@@ -125,7 +125,7 @@ describe("FTPContext", function() {
         ftp.socket.once("didSend", buf => {
             assert.equal(buf.toString(), "HELLO 直己\r\n");
             done();
-        }); 
+        });
         ftp.send("HELLO 直己");
     });
 

--- a/test/parseControlResponseSpec.js
+++ b/test/parseControlResponseSpec.js
@@ -8,13 +8,13 @@ describe("Parse multiline response", function() {
     const tests = [
         {
             title: "Single line",
-            res: `200 A`,
-            exp: { messages: [`200 A`], rest: "" }
+            res: "200 A",
+            exp: { messages: ["200 A"], rest: "" }
         },
         {
             title: "Single line with an extra CRLF",
             res: `200 A${CRLF}`,
-            exp: { messages: [`200 A`], rest: "" }
+            exp: { messages: ["200 A"], rest: "" }
         },
         {
             title: "Multiline: 1 response group",

--- a/test/parseControlResponseSpec.js
+++ b/test/parseControlResponseSpec.js
@@ -40,7 +40,7 @@ describe("Parse multiline response", function() {
             title: "Multline: No closing tag",
             res: `150-A${CRLF}160-B${CRLF}150 C${CRLF}200-D`,
             exp: { messages: [`150-A${LF}160-B${LF}150 C`], rest: `200-D${LF}` }
-        },               
+        },
     ];
     for (const test of tests) {
         it(test.title, function() {

--- a/test/parseListSpec.js
+++ b/test/parseListSpec.js
@@ -22,61 +22,62 @@ const listDOS = `
 const listUnknown = `
 a
 b
-`
+`;
 const listUnknownMVS = `
 SAVE00 3390   2004/06/23  1    1  FB     128  6144  PS    INCOMING.RPTBM023.D061704
 SAVE01 3390   2004/06/23  1    1  FB     128  6144  PO    INCOMING.RPTBM024.D061704
 `;
 
 describe("Directory listing", function() {
+    let f;
     const tests = [
         {
             title: "Regular Unix list",
             list: listUnix,
             exp: [
-                (f = new FileInfo("LICENSE.txt"), 
-                    f.group = "staff", 
-                    f.size = 1057, 
-                    f.user = "patrick",
-                    f.permissions = {
-                        user: FileInfo.Permission.Read + FileInfo.Permission.Write,
-                        group: FileInfo.Permission.Read,
-                        world: FileInfo.Permission.Read
-                    },
-                    f.hardLinkCount = 1,
-                    f.date = "Dec 11 14:35",
-                    f.type = FileInfo.Type.File,
-                    f),
-                (f = new FileInfo("lib"), 
-                    f.group = "staff", 
-                    f.size = 170, 
-                    f.user = "patrick", 
-                    f.permissions = {
-                        user: FileInfo.Permission.Read + FileInfo.Permission.Write + FileInfo.Permission.Execute,
-                        group: FileInfo.Permission.Read + FileInfo.Permission.Execute,
-                        world: FileInfo.Permission.Read + FileInfo.Permission.Execute
-                    },
-                    f.hardLinkCount = 5,
-                    f.date = "Dec 11 17:24",
-                    f.type = FileInfo.Type.Directory, 
-                    f),
-            ]  
+                (f = new FileInfo("LICENSE.txt"),
+                f.group = "staff",
+                f.size = 1057,
+                f.user = "patrick",
+                f.permissions = {
+                    user: FileInfo.Permission.Read + FileInfo.Permission.Write,
+                    group: FileInfo.Permission.Read,
+                    world: FileInfo.Permission.Read
+                },
+                f.hardLinkCount = 1,
+                f.date = "Dec 11 14:35",
+                f.type = FileInfo.Type.File,
+                f),
+                (f = new FileInfo("lib"),
+                f.group = "staff",
+                f.size = 170,
+                f.user = "patrick",
+                f.permissions = {
+                    user: FileInfo.Permission.Read + FileInfo.Permission.Write + FileInfo.Permission.Execute,
+                    group: FileInfo.Permission.Read + FileInfo.Permission.Execute,
+                    world: FileInfo.Permission.Read + FileInfo.Permission.Execute
+                },
+                f.hardLinkCount = 5,
+                f.date = "Dec 11 17:24",
+                f.type = FileInfo.Type.Directory,
+                f),
+            ]
         },
         {
             title: "Regular DOS list",
             list: listDOS,
             exp: [
-                (f = new FileInfo("myDir"), 
-                    f.size = 0,
-                    f.date = "12-05-96 05:03PM",
-                    f.type = FileInfo.Type.Directory, 
-                    f),
-                (f = new FileInfo("MYFILE.INI"), 
-                    f.size = 953,
-                    f.date = "11-14-97 04:21PM",
-                    f.type = FileInfo.Type.File, 
-                    f),
-            ]  
+                (f = new FileInfo("myDir"),
+                f.size = 0,
+                f.date = "12-05-96 05:03PM",
+                f.type = FileInfo.Type.Directory,
+                f),
+                (f = new FileInfo("MYFILE.INI"),
+                f.size = 953,
+                f.date = "11-14-97 04:21PM",
+                f.type = FileInfo.Type.File,
+                f),
+            ]
         },
         {
             title: "Unknown format",
@@ -98,13 +99,13 @@ describe("Directory listing", function() {
         it(test.title, function() {
             if (test.exp) {
                 const actual = parseList(test.list);
-                assert.deepEqual(actual, test.exp);    
+                assert.deepEqual(actual, test.exp);
             }
             else {
                 assert.throws(function() {
                     parseList(test.list);
                 });
             }
-        });        
+        });
     }
 });

--- a/test/parsePasvResponseSpec.js
+++ b/test/parsePasvResponseSpec.js
@@ -5,6 +5,6 @@ describe("Parse PASV response", function() {
     it("can parse IPv4", function() {
         const result = parseIPv4("227 Entering Passive Mode (192,168,1,100,10,229)");
         assert.equal(result.host, "192.168.1.100", "Host");
-        assert.equal(result.port, 2789, "Port")
+        assert.equal(result.port, 2789, "Port");
     });
 });

--- a/test/progressTrackerSpec.js
+++ b/test/progressTrackerSpec.js
@@ -4,7 +4,7 @@ const SocketMock = require("./SocketMock");
 
 describe("ProgressTracker", function() {
     this.timeout(100);
-    
+
     let socket, tracker;
     beforeEach(function() {
         socket = new SocketMock();
@@ -27,7 +27,7 @@ describe("ProgressTracker", function() {
 
     it("can stop without update on more time", function() {
         tracker.start(socket);
-        tracker.reportTo(info => {
+        tracker.reportTo(() => {
             assert.fail("This update should not be called.");
         });
         tracker.stop();
@@ -44,7 +44,7 @@ describe("ProgressTracker", function() {
             }, "Final values");
             done();
         });
-        tracker.updateAndStop();        
+        tracker.updateAndStop();
     });
 
     it("reports correct values at stop after no intermediate updates", function(done) {
@@ -60,7 +60,7 @@ describe("ProgressTracker", function() {
         });
         socket.bytesWritten = 2;
         socket.bytesRead = 3;
-        tracker.updateAndStop();                
+        tracker.updateAndStop();
     });
 
     it("does progress reports at an interval", function(done) {
@@ -73,7 +73,7 @@ describe("ProgressTracker", function() {
                 type: "type",
                 bytes: count,
                 bytesOverall: count
-            }, "Progress info")
+            }, "Progress info");
             socket.bytesWritten += 1;
             if (++count === 3) {
                 tracker.reportTo();
@@ -98,12 +98,12 @@ describe("ProgressTracker", function() {
 
     it("can stop within the callback", function() {
         let firstTime = true;
-        tracker.reportTo(info => {
+        tracker.reportTo(() => {
             // Will be called on start
             tracker.reportTo();
             assert(firstTime, "Should not be called twice.");
             firstTime = false;
-        })
+        });
         tracker.start(socket);
         tracker.updateAndStop();
     });

--- a/test/transferResolverSpec.js
+++ b/test/transferResolverSpec.js
@@ -18,7 +18,7 @@ describe("TransferResolver", function() {
                 assert.equal(result, "result");
                 done();
             }
-        }
+        };
         resolver.resolve(task, "result");
         bothCalled = true;
         resolver.confirm(task);
@@ -30,7 +30,7 @@ describe("TransferResolver", function() {
                 assert.equal(result, "result");
                 done();
             }
-        }
+        };
         resolver.confirm(task);
         resolver.resolve(task, "result");
     });
@@ -41,7 +41,7 @@ describe("TransferResolver", function() {
                 assert.equal(reason, "reason");
                 done();
             }
-        }
+        };
         resolver.confirm(task, "something");
         resolver.reject(task, "reason");
     });
@@ -49,7 +49,7 @@ describe("TransferResolver", function() {
     it("resolving destroys data socket", function() {
         const task = {
             resolve() {},
-        }
+        };
         assert.equal(resolver.ftp.dataSocket, true);
         resolver.resolve(task, "foo");
         assert.equal(resolver.ftp.dataSocket, true);
@@ -60,7 +60,7 @@ describe("TransferResolver", function() {
     it("rejecting destroys data socket", function() {
         const task = {
             reject() {},
-        }
+        };
         assert.equal(resolver.ftp.dataSocket, true);
         resolver.reject(task, "foo");
         assert.equal(resolver.ftp.dataSocket, undefined, "dataSocket not set to undefined");

--- a/test/transferResolverSpec.js
+++ b/test/transferResolverSpec.js
@@ -9,7 +9,7 @@ describe("TransferResolver", function() {
             dataSocket: true
         });
     });
-    
+
     it("handles resolve, then confirm", function(done) {
         let bothCalled = false;
         const task = {

--- a/test/uploadSpec.js
+++ b/test/uploadSpec.js
@@ -26,7 +26,7 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "STOR NAME.TXT\r\n");
             done();
         });
-        const promise = client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT");
     });
 
     it("starts uploading after receiving 'ready to upload'", function(done) {
@@ -36,7 +36,7 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "123", "Wrong data sent");
             done();
         });
-        const promise = client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT");
         setTimeout(() => {
             didSendReady = true;
             client.ftp.socket.emit("data", Buffer.from("150 Ready"));
@@ -52,18 +52,18 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "123", "Wrong data sent");
             done();
         });
-        const promise = client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT");
         setTimeout(() => {
             client.ftp.socket.emit("data", Buffer.from("150 Ready"));
             setTimeout(() => {
                 client.ftp.dataSocket.emit("secureConnect");
-                didWait = true;    
+                didWait = true;
             });
         });
     });
-    
+
     it("explicitly closes the data socket when all has been transmitted", function(done) {
-        client.ftp.dataSocket.on("didSend", buf => {
+        client.ftp.dataSocket.on("didSend", () => {
             // Finish event should trigger closing of data socket.
             client.ftp.dataSocket.emit("finish");
             setTimeout(() => {
@@ -71,7 +71,7 @@ describe("Upload", function() {
                 done();
             });
         });
-        const promise = client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT");
         setTimeout(() => {
             client.ftp.socket.emit("data", Buffer.from("150 Ready"));
             // Don't send completion message, we don't want the TransferResolver
@@ -80,23 +80,23 @@ describe("Upload", function() {
     });
 
     it("handles control confirmation before data sent completely", function() {
-        client.ftp.dataSocket.on("didSend", buf => {
+        client.ftp.dataSocket.on("didSend", () => {
             client.ftp.dataSocket.emit("finish");
-            setTimeout(() => client.ftp.socket.emit("data", Buffer.from("200 Done"))); 
+            setTimeout(() => client.ftp.socket.emit("data", Buffer.from("200 Done")));
         });
         const promise = client.upload(readable, "NAME.TXT");
         setTimeout(() => client.ftp.socket.emit("data", Buffer.from("150 Ready")));
-        return promise;        
+        return promise;
     });
 
     it("handles data sent completely before control confirmation", function() {
-        client.ftp.dataSocket.on("didSend", buf => {
+        client.ftp.dataSocket.on("didSend", () => {
             client.ftp.dataSocket.emit("finish");
-            setTimeout(() => client.ftp.socket.emit("data", Buffer.from("200 Done"))); 
+            setTimeout(() => client.ftp.socket.emit("data", Buffer.from("200 Done")));
         });
         const promise = client.upload(readable, "NAME.TXT");
         setTimeout(() => client.ftp.socket.emit("data", Buffer.from("150 Ready")));
-        return promise;        
+        return promise;
     });
 
     it("handles errors", function(done) {
@@ -110,4 +110,4 @@ describe("Upload", function() {
             client.ftp.socket.emit("data", Buffer.from("500 Error"));
         });
     });
-}); 
+});


### PR DESCRIPTION
Sorry, 'meant this to be a simple commit to remove the trailing whitespace, but ...
* ... saw the `eslintrc` file so added the `no-trailing-whitespace` rule there
* ... and added `eslint` to the `npm test` command to enforce eslint rules (2nd commit)
* ... which caused tests to fail
* ... so ran `eslint --fix .` to fixup the whitespace and indent issues
* ... and cleaned up the remaining issues (3rd commit)

*sigh*... sorry. :-)