### PR TITLE
Rework FTP context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Non-breaking changes:
 - Added: If there is a socket error outside of a task, the following task will receive it. (#43)
 - Changed: Improved feedback if a developer forgets to use `await` or `.then()` for tasks. (#36)
 
+Special thanks to @broofa for feedback and reviews.
+
 ## 2.17.1
 
 - Fixed: Multibyte UTF-8 arriving in multiple chunks (#38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.0
+
+This release contains the following breaking changes:
+
+- Changed: `Client` is now single-use only. It can't be used anymore once it closes and a new client has to be instantiated.
+- Changed: All exceptions are now instances of `Error`, not custom error objects. Introduced `FTPError` for errors specific to FTP. (#37)
+
+Non-breaking changes:
+
+- Added: If there is a socket error outside of a task, the following task will receive it. (#43)
+- Changed: Improved feedback if a developer forgets to use `await` or `.then()` for tasks. (#36)
+
 ## 2.17.1
 
 - Fixed: Multibyte UTF-8 arriving in multiple chunks (#38)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Any error reported by the FTP server will be thrown as `FTPError`. The connectio
 
 This is different with a timeout or connection error: In addition to an `Error` being thrown, any connection to the FTP server will be closed. You’ll have to instantiate a new `Client` and reconnect, if you want to continue any work.
 
+## Logging
+
+Using `client.ftp.verbose = true` will log debug-level information to the console. You can use your own logging library by overriding `client.ftp.log`. This method is called regardless of what `client.ftp.verbose` is set to. For example:
+
+```
+myClient.ftp.log = myLogger.debug
+```
+
 ## Extending the library
 
 ### Custom strategies

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Create a client instance using a timeout in milliseconds that will be used for c
 
 Close the client and all open socket connections. The client can’t be used anymore after calling this method, you have to instantiate a new one to continue any work. A client is also closed automatically if any timeout or connection error occurs. See the section on [Error Handling](#error-handling) below.
 
+`closed`
+
+True if the client has been closed, either by the user or by an error.
+
 `access(options): Promise<Response>`
 
 Get access to an FTP server. This method will connect to a server, optionally secure the connection with TLS, login a user and apply some default settings (TYPE I, STRU F, PBSZ 0, PROT P). It returns the response of the initial connect command. The available options are:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an FTP client for Node.js. It supports explicit FTPS over TLS, Passive M
 
 ## Advisory
 
-Prefer alternative transfer protocols like SFTP (SSH) if you can. Use this library when you have no choice and need to use FTP. Try to use FTPS whenever possible, FTP alone does not encrypt your data.
+Prefer alternative transfer protocols like HTTP or SFTP (SSH) if you can. Use this library when you have no choice and need to use FTP. Try to use FTPS whenever possible, FTP alone does not encrypt your data.
 
 ## Dependencies
 

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -274,6 +274,8 @@ exports.FTPContext = class FTPContext {
                 responseHandler
             };
             if (this._closingError) {
+                // This client has been closed. Provide an error that describes this one as being caused
+                // by `_closingError`, include stack traces for both.
                 const err = new Error(`Client has been closed earlier: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 this._passToHandler(err);

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -116,11 +116,17 @@ exports.FTPContext = class FTPContext {
      * Close the context by resetting its state.
      */
     close() {
-        // Close with an error - if there is an active task it will receive it. If not, the next submitted
-        // task will be rejected with a similar explanation. Plus, the user gets a stack trace in case
-        // it's not clear where exactly the client was closed. This also keeps the code simple because
-        // we now only have a single code-path for closing: `_closeWithError()`.
-        const err = this._task ? new Error("User closed client during task") : new Error("User closed client");
+        // If this context already has been closed, don't overwrite the reason.
+        if (this._closingError) {
+            return;
+        }
+        // Close with an error: If there is an active task it will receive it justifiably because the user
+        // closed while a task was still running. If no task is running, no error will be thrown (see _closeWithError)
+        // but all newly submitted tasks after that will be rejected because "the client is closed". Plus, the user
+        // gets a stack trace in case it's not clear where exactly the client was closed. We use _closingError to
+        // determine whether a context is closed. This also allows us to have a single code-path for closing a context.
+        const message = this._task ? "User closed client during task" : "User closed client";
+        const err = new Error(message);
         this._closeWithError(err);
     }
 

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -6,12 +6,28 @@ const parseControlResponse = require("./parseControlResponse");
 /**
  * @typedef {Object} Task
  * @property {(...args: any[]) => void} resolve - Resolves the task.
- * @property {(...args: any[]) => void} reject - Rejects the task.
+ * @property {(err: Error) => void} reject - Rejects the task.
  */
 
 /**
- * @typedef {(response: Object, task: Task) => void} ResponseHandler
+ * @typedef {Object} FTPResponse
+ * @property {number} code - FTP response code
+ * @property {string} message - FTP response including code
  */
+
+/**
+ * @typedef {(err: Error | undefined, response: FTPResponse | undefined, task: Task) => void} ResponseHandler
+ */
+
+/**
+ * Describes an FTP server error response including the FTP response code.
+ */
+class FTPError extends Error {
+    get name() {
+        return this.constructor.name;
+    }
+}
+exports.FTPError = FTPError;
 
 /**
  * FTPContext holds the control and data sockets of an FTP connection and provides a
@@ -20,7 +36,7 @@ const parseControlResponse = require("./parseControlResponse");
  * It doesn't implement or use any FTP commands. It's only a foundation to make writing an FTP
  * client as easy as possible. You won't usually instantiate this, but use `Client`.
  */
-module.exports = class FTPContext {
+exports.FTPContext = class FTPContext {
 
     /**
      * Instantiate an FTP context.
@@ -89,7 +105,7 @@ module.exports = class FTPContext {
      * Close the context by resetting its state.
      */
     close() {
-        this._passToHandler({ error: { info: "User closed client during task." }});
+        this._passToHandler(new Error("User closed client during task."));
         this._reset();
     }
 
@@ -231,9 +247,9 @@ module.exports = class FTPContext {
                     this._stopTrackingTask();
                     resolvePromise(...args);
                 },
-                reject: (...args) => {
+                reject: err => {
                     this._stopTrackingTask();
-                    rejectPromise(...args);
+                    rejectPromise(err);
                 }
             };
             if (command !== undefined) {
@@ -270,7 +286,9 @@ module.exports = class FTPContext {
         // Each response group is passed along individually.
         for (const message of parsed.messages) {
             const code = parseInt(message.substr(0, 3), 10);
-            this._passToHandler({ code, message });
+            const err = code >= 400 ? new FTPError(message) : undefined;
+            const response = { code, message };
+            this._passToHandler(err, response);
         }
     }
 
@@ -279,11 +297,12 @@ module.exports = class FTPContext {
      * or a socket event, like an error or timeout.
      *
      * @private
-     * @param {Object} response
+     * @param {(Error | undefined)} err
+     * @param {(FTPResponse | undefined)} [response]
      */
-    _passToHandler(response) {
+    _passToHandler(err, response) {
         if (this._handler) {
-            this._handler(response, this._task);
+            this._handler(err, response, this._task);
         }
     }
 
@@ -306,11 +325,10 @@ module.exports = class FTPContext {
      * Send an error to the current handler and close all connections.
      *
      * @private
-     * @param {*} error
+     * @param {Error} err
      */
-    _closeWithError(error) {
-        this.log(error);
-        this._passToHandler({ error });
+    _closeWithError(err) {
+        this._passToHandler(err);
         this._reset();
     }
 
@@ -333,13 +351,18 @@ module.exports = class FTPContext {
      * @private
      * @param {Socket} socket
      * @param {string} identifier
+     *
+     *
      */
     _setupErrorHandlers(socket, identifier) {
-        socket.once("error", error => this._closeWithError({ ...error, ftpSocket: identifier }));
-        socket.once("timeout", () => this._closeWithError({ info: "socket timeout", ftpSocket: identifier }));
+
+        // TODO how to deal with socket identifiers?
+
+        socket.once("error", error => this._closeWithError(error));
+        socket.once("timeout", () => this._closeWithError(new Error(`Socket timeout (${identifier})`)));
         socket.once("close", hadError => {
             if (hadError) {
-                this._closeWithError({ info: "socket closed due to transmission error", ftpSocket: identifier});
+                this._closeWithError(new Error(`Socket closed due to transmission error (${identifier})`));
             }
         });
     }
@@ -351,7 +374,8 @@ module.exports = class FTPContext {
      * @param {Socket} socket
      */
     _removeSocketListeners(socket) {
-        // socket.removeAllListeners() without name doesn't work: https://github.com/nodejs/node/issues/20923
+        socket.removeAllListeners();
+        // socket.removeAllListeners() without name might not work: https://github.com/nodejs/node/issues/20923
         socket.removeAllListeners("timeout");
         socket.removeAllListeners("data");
         socket.removeAllListeners("error");

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -7,7 +7,7 @@ const parseControlResponse = require("./parseControlResponse");
  * @typedef {Object} Task
  * @property {ResponseHandler} responseHandler - Handles a response for a task.
  * @property {TaskResolver} resolver - Resolves or rejects a task.
- * @property {string} stack
+ * @property {string} stack - Call stack when task is run.
  */
 
 /**
@@ -258,8 +258,6 @@ exports.FTPContext = class FTPContext {
     handle(command, responseHandler) {
         if (this._task) {
             // The user or client instance called `handle()` while a task is still running.
-            // TODO throw once
-            // TODO provide stack trace to previous task
             const err = new Error("User launched a task while another one is still running. Forgot to use 'await' or '.then()'?");
             err.stack += `\nRunning task launched at: ${this._task.stack}`;
             this._closeWithError(err);

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -115,7 +115,7 @@ exports.FTPContext = class FTPContext {
     /**
      * Close the context.
      *
-     * The context can’t be used anymore after calling this method, you have to instantiate a new one to continue any work.
+     * The context can’t be used anymore after calling this method.
      */
     close() {
         // If this context already has been closed, don't overwrite the reason.

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -5,6 +5,16 @@ const parseControlResponse = require("./parseControlResponse");
 
 /**
  * @typedef {Object} Task
+ * @property {ResponseHandler} responseHandler - Handles a response for a task.
+ * @property {TaskResolver} resolver - Resolves or rejects a task.
+ */
+
+/**
+ * @typedef {(err: Error | undefined, response: FTPResponse | undefined, task: TaskResolver) => void} ResponseHandler
+ */
+
+/**
+ * @typedef {Object} TaskResolver
  * @property {(...args: any[]) => void} resolve - Resolves the task.
  * @property {(err: Error) => void} reject - Rejects the task.
  */
@@ -13,10 +23,6 @@ const parseControlResponse = require("./parseControlResponse");
  * @typedef {Object} FTPResponse
  * @property {number} code - FTP response code
  * @property {string} message - FTP response including code
- */
-
-/**
- * @typedef {(err: Error | undefined, response: FTPResponse | undefined, task: Task) => void} ResponseHandler
  */
 
 /**
@@ -63,17 +69,17 @@ exports.FTPContext = class FTPContext {
          */
         this._task = undefined;
         /**
-         * Function that handles incoming messages and resolves or rejects a task.
-         * @private
-         * @type {(ResponseHandler | undefined)}
-         */
-        this._handler = undefined;
-        /**
          * A multiline response might be received as multiple chunks.
          * @private
          * @type {string}
          */
         this._partialResponse = "";
+        /**
+         * TODO describe
+         * @private
+         * @type {(Error | undefined)}
+         */
+        this._closingError = undefined;
         /**
          * The encoding used when reading from and writing to the control socket.
          * @type {string}
@@ -110,8 +116,12 @@ exports.FTPContext = class FTPContext {
      * Close the context by resetting its state.
      */
     close() {
-        this._passToHandler(new Error("User closed client during task."));
-        this._reset();
+        // Close with an error - if there is an active task it will receive it. If not, the next submitted
+        // task will be rejected with a similar explanation. Plus, the user gets a stack trace in case
+        // it's not clear where exactly the client was closed. This also keeps the code simple because
+        // we now only have a single code-path for closing: `_closeWithError()`.
+        const err = this._task ? new Error("User closed client during task") : new Error("User closed client");
+        this._closeWithError(err);
     }
 
     /** @type {Socket} */
@@ -233,21 +243,15 @@ exports.FTPContext = class FTPContext {
      * will hold whatever the handler passed on when resolving/rejecting its task.
      *
      * @param {string} command
-     * @param {ResponseHandler} handler
+     * @param {ResponseHandler} responseHandler
      * @returns {Promise<any>}
      */
-    handle(command, handler) {
-        if (this._handler !== undefined) {
-            this._closeWithError(new Error("There is still a task running. Did you forget to use '.then()' or 'await'?"));
+    handle(command, responseHandler) {
+        if (this._task) {
+            // TODO provide helpful information if user forgot to await
         }
-        // Only track control socket timeout during the lifecycle of a task associated with a handler.
-        // That way we avoid timeouts on idle sockets, a behaviour that is not expected by most users.
-        this.enableControlTimeout(true);
         return new Promise((resolvePromise, rejectPromise) => {
-            this._handler = handler;
-            this._task = {
-                // When resolving or rejecting we also want the handler
-                // to no longer receive any responses or errors.
+            const resolver = {
                 resolve: (...args) => {
                     this._stopTrackingTask();
                     resolvePromise(...args);
@@ -257,7 +261,18 @@ exports.FTPContext = class FTPContext {
                     rejectPromise(err);
                 }
             };
-            if (command !== undefined) {
+            this._task = {
+                resolver,
+                responseHandler
+            };
+            if (this._closingError) {
+                // TODO ideal would be to nest the closing error or prepend message: "Client closed: [this._closingError]"
+                this._passToHandler(this._closingError);
+            }
+            else if (command) {
+                // Only track control socket timeout during the lifecycle of a task. This avoids timeouts on idle sockets,
+                // the default socket behaviour which is not expected by most users.
+                this.enableControlTimeout(true);
                 this.send(command);
             }
         });
@@ -270,7 +285,6 @@ exports.FTPContext = class FTPContext {
         // Disable timeout on control socket if there is no task active.
         this.enableControlTimeout(false);
         this._task = undefined;
-        this._handler = undefined;
     }
 
     /**
@@ -306,24 +320,16 @@ exports.FTPContext = class FTPContext {
      * @param {(FTPResponse | undefined)} [response]
      */
     _passToHandler(err, response) {
-        if (this._handler) {
-            this._handler(err, response, this._task);
+        if (this._task) {
+            this._task.responseHandler(err, response, this._task.resolver);
         }
-    }
+        // Errors other than FTPError always close the client. If there isn't an active task to handle the error,
+        // the next one submitted will receive it using `_closingError`.
 
-    /**
-     * Reset the state of this context.
-     *
-     * @private
-     */
-    _reset() {
-        this.log("Closing connections.");
-        this._stopTrackingTask();
-        this._partialResponse = "";
-        this._closeSocket(this._socket);
-        this._closeSocket(this._dataSocket);
-        // Set a new socket instance to make reconnecting possible.
-        this.socket = new Socket();
+        // TODO There is only one edge-case: If there is an FTPError while no task is active, the error will be dropped.
+        // But that means that the user sent an FTP command with no intention of handling the result. So why should the
+        // error be handled? Maybe log it at least? Debug logging will already do that and the client stays useable after
+        // FTPError. So maybe no need to do anything here.
     }
 
     /**
@@ -333,21 +339,14 @@ exports.FTPContext = class FTPContext {
      * @param {Error} err
      */
     _closeWithError(err) {
+        this._closingError = err;
+        // Before giving the user's task a chance to react, make sure we won't be bothered with any inputs.
+        this._closeSocket(this._socket);
+        this._closeSocket(this._dataSocket);
+        // Give the user's task a chance to react, maybe cleanup resources.
         this._passToHandler(err);
-        this._reset();
-    }
-
-    /**
-     * Close a socket.
-     *
-     * @private
-     * @param {(Socket | undefined)} socket
-     */
-    _closeSocket(socket) {
-        if (socket) {
-            socket.destroy();
-            this._removeSocketListeners(socket);
-        }
+        // The task might not have been rejected by the user after receiving the error.
+        this._stopTrackingTask();
     }
 
     /**
@@ -368,6 +367,19 @@ exports.FTPContext = class FTPContext {
             }
         });
         socket.once("timeout", () => this._closeWithError(new Error(`Timeout (${identifier})`)));
+    }
+
+    /**
+     * Close a socket.
+     *
+     * @private
+     * @param {(Socket | undefined)} socket
+     */
+    _closeSocket(socket) {
+        if (socket) {
+            socket.destroy();
+            this._removeSocketListeners(socket);
+        }
     }
 
     /**

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -272,8 +272,9 @@ exports.FTPContext = class FTPContext {
                 responseHandler
             };
             if (this._closingError) {
-                // TODO ideal would be to nest the closing error or prepend message: "Client closed: [this._closingError]"
-                this._passToHandler(this._closingError);
+                const err = new Error(`Client has been closed earlier, reason: ${this._closingError.message}`);
+                err.stack += `\nCaused by: ${this._closingError.stack}`;
+                this._passToHandler(err);
             }
             else if (command) {
                 // Only track control socket timeout during the lifecycle of a task. This avoids timeouts on idle sockets,

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -360,8 +360,6 @@ exports.FTPContext = class FTPContext {
      * @private
      * @param {Socket} socket
      * @param {string} identifier
-     *
-     *
      */
     _setupErrorHandlers(socket, identifier) {
         socket.once("error", error => {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -143,7 +143,7 @@ exports.FTPContext = class FTPContext {
             socket.setKeepAlive(true);
             // @ts-ignore that data is of type string here, not data.
             socket.on("data", data => this._onControlSocketData(data));
-            this._setupErrorHandlers(socket, "control");
+            this._setupErrorHandlers(socket, "control socket");
         }
         else {
             this._closeSocket(this._socket);
@@ -165,7 +165,7 @@ exports.FTPContext = class FTPContext {
         this._closeSocket(this._dataSocket);
         if (socket) {
             socket.setTimeout(this._timeout);
-            this._setupErrorHandlers(socket, "data");
+            this._setupErrorHandlers(socket, "data socket");
         }
         this._dataSocket = socket;
     }

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -373,7 +373,7 @@ exports.FTPContext = class FTPContext {
                 this._closeWithError(new Error(`Socket closed due to transmission error (${identifier})`));
             }
         });
-        socket.once("timeout", () => this._closeWithError(new Error(`Socket timeout (${identifier})`)));
+        socket.once("timeout", () => this._closeWithError(new Error(`Timeout (${identifier})`)));
     }
 
     /**

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -7,6 +7,7 @@ const parseControlResponse = require("./parseControlResponse");
  * @typedef {Object} Task
  * @property {ResponseHandler} responseHandler - Handles a response for a task.
  * @property {TaskResolver} resolver - Resolves or rejects a task.
+ * @property {string} stack
  */
 
 /**
@@ -259,7 +260,9 @@ exports.FTPContext = class FTPContext {
             // The user or client instance called `handle()` while a task is still running.
             // TODO throw once
             // TODO provide stack trace to previous task
-            this._closeWithError(new Error("User launched a task while another one is still running. Forgot to use 'await' or '.then()'?"));
+            const err = new Error("User launched a task while another one is still running. Forgot to use 'await' or '.then()'?");
+            err.stack += `\nRunning task launched at: ${this._task.stack}`;
+            this._closeWithError(err);
         }
         return new Promise((resolvePromise, rejectPromise) => {
             const resolver = {
@@ -273,6 +276,7 @@ exports.FTPContext = class FTPContext {
                 }
             };
             this._task = {
+                stack: new Error().stack,
                 resolver,
                 responseHandler
             };

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -256,7 +256,10 @@ exports.FTPContext = class FTPContext {
      */
     handle(command, responseHandler) {
         if (this._task) {
-            // TODO provide helpful information if user forgot to await
+            // The user or client instance called `handle()` while a task is still running.
+            // TODO throw once
+            // TODO provide stack trace to previous task
+            this._closeWithError(new Error("User launched a task while another one is still running. Forgot to use 'await' or '.then()'?"));
         }
         return new Promise((resolvePromise, rejectPromise) => {
             const resolver = {
@@ -276,7 +279,7 @@ exports.FTPContext = class FTPContext {
             if (this._closingError) {
                 // This client has been closed. Provide an error that describes this one as being caused
                 // by `_closingError`, include stack traces for both.
-                const err = new Error(`Client has been closed earlier: ${this._closingError.message}`);
+                const err = new Error(`Client has been closed: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 this._passToHandler(err);
             }

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -378,7 +378,7 @@ exports.FTPContext = class FTPContext {
      */
     _removeSocketListeners(socket) {
         socket.removeAllListeners();
-        // socket.removeAllListeners() without name might not work: https://github.com/nodejs/node/issues/20923
+        // Before Node.js 10.3.0, using `socket.removeAllListeners()` without any name did not work: https://github.com/nodejs/node/issues/20923.
         socket.removeAllListeners("timeout");
         socket.removeAllListeners("data");
         socket.removeAllListeners("error");

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -336,8 +336,7 @@ exports.FTPContext = class FTPContext {
         }
         // Errors other than FTPError always close the client. If there isn't an active task to handle the error,
         // the next one submitted will receive it using `_closingError`.
-
-        // TODO There is only one edge-case: If there is an FTPError while no task is active, the error will be dropped.
+        // There is only one edge-case: If there is an FTPError while no task is active, the error will be dropped.
         // But that means that the user sent an FTP command with no intention of handling the result. So why should the
         // error be handled? Maybe log it at least? Debug logging will already do that and the client stays useable after
         // FTPError. So maybe no need to do anything here.

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -291,10 +291,7 @@ exports.FTPContext = class FTPContext {
                 const err = new Error(`Client has been closed: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 // @ts-ignore that `Error` doesn't have `code` by default.
-                if (this._closingError.code) {
-                    // @ts-ignore
-                    err.code = this._closingError.code;
-                }
+                err.code = this._closingError.code !== undefined ? this._closingError.code : 0
                 this._passToHandler(err);
             }
             else if (command) {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -284,7 +284,10 @@ exports.FTPContext = class FTPContext {
                 const err = new Error(`Client has been closed: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 // @ts-ignore that `Error` doesn't have `code` by default.
-                err.code = this._closingError.code;
+                if (this._closingError.code) {
+                    // @ts-ignore
+                    err.code = this._closingError.code;
+                }
                 this._passToHandler(err);
             }
             else if (command) {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -283,6 +283,8 @@ exports.FTPContext = class FTPContext {
                 // by `_closingError`, include stack traces for both.
                 const err = new Error(`Client has been closed: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
+                // @ts-ignore that `Error` doesn't have `code` by default.
+                err.code = this._closingError.code;
                 this._passToHandler(err);
             }
             else if (command) {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -113,7 +113,9 @@ exports.FTPContext = class FTPContext {
     }
 
     /**
-     * Close the context by resetting its state.
+     * Close the context.
+     *
+     * The context can’t be used anymore after calling this method, you have to instantiate a new one to continue any work.
      */
     close() {
         // If this context already has been closed, don't overwrite the reason.

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -364,18 +364,16 @@ exports.FTPContext = class FTPContext {
      *
      */
     _setupErrorHandlers(socket, identifier) {
-
-        // TODO how to deal with socket identifiers?
-
         socket.once("error", error => {
+            error.message += ` (${identifier})`;
             this._closeWithError(error);
         });
-        socket.once("timeout", () => this._closeWithError(new Error(`Socket timeout (${identifier})`)));
         socket.once("close", hadError => {
             if (hadError) {
                 this._closeWithError(new Error(`Socket closed due to transmission error (${identifier})`));
             }
         });
+        socket.once("timeout", () => this._closeWithError(new Error(`Socket timeout (${identifier})`)));
     }
 
     /**

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -23,17 +23,13 @@ const parseControlResponse = require("./parseControlResponse");
  * Describes an FTP server error response including the FTP response code.
  */
 class FTPError extends Error {
-
     /**
      * @param {FTPResponse} res
      */
     constructor(res) {
         super(res.message);
+        this.name = this.constructor.name;
         this.code = res.code;
-    }
-
-    get name() {
-        return this.constructor.name;
     }
 }
 exports.FTPError = FTPError;

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -274,7 +274,7 @@ exports.FTPContext = class FTPContext {
                 responseHandler
             };
             if (this._closingError) {
-                const err = new Error(`Client has been closed earlier, reason: ${this._closingError.message}`);
+                const err = new Error(`Client has been closed earlier: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 this._passToHandler(err);
             }

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -133,6 +133,13 @@ exports.FTPContext = class FTPContext {
         this._closeWithError(err);
     }
 
+    /**
+     * @returns {boolean}
+     */
+    get closed() {
+        return this._closingError !== undefined;
+    }
+
     /** @type {Socket} */
     get socket() {
         return this._socket;

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -291,7 +291,7 @@ exports.FTPContext = class FTPContext {
                 const err = new Error(`Client has been closed: ${this._closingError.message}`);
                 err.stack += `\nCaused by: ${this._closingError.stack}`;
                 // @ts-ignore that `Error` doesn't have `code` by default.
-                err.code = this._closingError.code !== undefined ? this._closingError.code : 0
+                err.code = this._closingError.code !== undefined ? this._closingError.code : 0;
                 this._passToHandler(err);
             }
             else if (command) {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -23,6 +23,15 @@ const parseControlResponse = require("./parseControlResponse");
  * Describes an FTP server error response including the FTP response code.
  */
 class FTPError extends Error {
+
+    /**
+     * @param {FTPResponse} res
+     */
+    constructor(res) {
+        super(res.message);
+        this.code = res.code;
+    }
+
     get name() {
         return this.constructor.name;
     }
@@ -286,8 +295,8 @@ exports.FTPContext = class FTPContext {
         // Each response group is passed along individually.
         for (const message of parsed.messages) {
             const code = parseInt(message.substr(0, 3), 10);
-            const err = code >= 400 ? new FTPError(message) : undefined;
             const response = { code, message };
+            const err = code >= 400 ? new FTPError(response) : undefined;
             this._passToHandler(err, response);
         }
     }
@@ -358,7 +367,9 @@ exports.FTPContext = class FTPContext {
 
         // TODO how to deal with socket identifiers?
 
-        socket.once("error", error => this._closeWithError(error));
+        socket.once("error", error => {
+            this._closeWithError(error);
+        });
         socket.once("timeout", () => this._closeWithError(new Error(`Socket timeout (${identifier})`)));
         socket.once("close", hadError => {
             if (hadError) {

--- a/lib/FtpContext.js
+++ b/lib/FtpContext.js
@@ -288,8 +288,8 @@ exports.FTPContext = class FTPContext {
             if (this._closingError) {
                 // This client has been closed. Provide an error that describes this one as being caused
                 // by `_closingError`, include stack traces for both.
-                const err = new Error(`Client has been closed: ${this._closingError.message}`);
-                err.stack += `\nCaused by: ${this._closingError.stack}`;
+                const err = new Error("Client is closed");
+                err.stack += `\nClosing reason: ${this._closingError.stack}`;
                 // @ts-ignore that `Error` doesn't have `code` by default.
                 err.code = this._closingError.code !== undefined ? this._closingError.code : 0;
                 this._passToHandler(err);

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -78,7 +78,7 @@ class Client {
             }
             else {
                 // Reject all other codes, including 120 "Service ready in nnn minutes".
-                task.reject(new Error(`Unexpected server response: ${res.message}`));
+                task.reject(new FTPError(res));
             }
         });
     }
@@ -143,7 +143,7 @@ class Client {
                 this.ftp.send("PASS " + password);
             }
             else { // Also report error on 332 (Need account)
-                task.reject(new Error(`Unexpected response from FTP server: ${res.message}`));
+                task.reject(new FTPError(res));
             }
         });
     }

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -7,7 +7,7 @@ const path = require("path");
 const promisify = require("util").promisify;
 const parseListAutoDetect = require("./parseList");
 const nullObject = require("./nullObject");
-const FTPContext = require("./FtpContext");
+const { FTPContext, FTPError } = require("./FtpContext");
 const FileInfo = require("./FileInfo");
 const StringWriter = require("./StringWriter");
 const ProgressTracker = require("./ProgressTracker");
@@ -67,13 +67,16 @@ class Client {
             port,
             family: this.ftp.ipFamily
         }, () => this.ftp.log(`Connected to ${describeAddress(this.ftp.socket)}`));
-        return this.ftp.handle(undefined, (res, task) => {
-            if (positiveCompletion(res.code)) {
+        return this.ftp.handle(undefined, (err, res, task) => {
+            if (err) {
+                task.reject(err);
+            }
+            else if (positiveCompletion(res.code)) {
                 task.resolve(res);
             }
             else {
                 // Reject all other codes, including 120 "Service ready in nnn minutes".
-                task.reject(res);
+                task.reject(new Error(`Unexpected response from FTP server: ${res.message}`));
             }
         });
     }
@@ -90,13 +93,15 @@ class Client {
      * @returns {Promise<PositiveResponse>}
      */
     send(command, ignoreErrorCodes = false) {
-        return this.ftp.handle(command, (res, task) => {
-            const success = res.code >= 200 && res.code < 400;
-            if (success || (res.code && ignoreErrorCodes)) {
+        return this.ftp.handle(command, (err, res, task) => {
+            if (err instanceof FTPError && ignoreErrorCodes) {
                 task.resolve(res);
             }
+            else if (err) {
+                task.reject(err);
+            }
             else {
-                task.reject(res);
+                task.resolve(res);
             }
         });
     }
@@ -125,15 +130,18 @@ class Client {
      */
     login(user = "anonymous", password = "guest") {
         this.ftp.log(`Login security: ${describeTLS(this.ftp.socket)}`);
-        return this.ftp.handle("USER " + user, (res, task) => {
-            if (positiveCompletion(res.code)) { // User logged in proceed OR Command superfluous
+        return this.ftp.handle("USER " + user, (err, res, task) => {
+            if (err) {
+                task.reject(err);
+            }
+            else if (positiveCompletion(res.code)) { // User logged in proceed OR Command superfluous
                 task.resolve(res);
             }
             else if (res.code === 331) { // User name okay, need password
                 this.ftp.send("PASS " + password);
             }
             else { // Also report error on 332 (Need account)
-                task.reject(res);
+                task.reject(new Error(`Unexpected response from FTP server: ${res.message}`));
             }
         });
     }
@@ -470,30 +478,47 @@ class TransferResolver {
      * @param {FTPContext} ftp
      */
     constructor(ftp) {
+        /** @type {FTPContext} */
         this.ftp = ftp;
-        this.result = undefined;
+        /** @type {(import("./FtpContext").FTPResponse | undefined)} */
+        this.response = undefined;
+        /** @type {boolean} */
         this.confirmed = false;
     }
 
-    resolve(task, result) {
-        this.result = result;
-        this._tryResolve(task);
-    }
-
+    /**
+     * @param {import("./FtpContext").Task} task
+     */
     confirm(task) {
         this.confirmed = true;
         this._tryResolve(task);
     }
 
-    reject(task, reason) {
+    /**
+     * @param {import("./FtpContext").Task} task
+     * @param {Error} err
+     */
+    reject(task, err) {
         this.ftp.dataSocket = undefined;
-        task.reject(reason);
+        task.reject(err);
     }
 
+    /**
+     * @param {import("./FtpContext").Task} task
+     * @param {import("./FtpContext").FTPResponse} response
+     */
+    resolve(task, response) {
+        this.response = response;
+        this._tryResolve(task);
+    }
+
+    /**
+     * @param {import("./FtpContext").Task} task
+     */
     _tryResolve(task) {
-        if (this.confirmed && this.result !== undefined) {
+        if (this.confirmed && this.response !== undefined) {
             this.ftp.dataSocket = undefined;
-            task.resolve(this.result);
+            task.resolve(this.response);
         }
     }
 }
@@ -753,8 +778,13 @@ function connectForPassiveTransfer(host, port, ftp) {
 function upload(ftp, progress, readableStream, remoteFilename) {
     const resolver = new TransferResolver(ftp);
     const command = "STOR " + remoteFilename;
-    return ftp.handle(command, (res, task) => {
-        if (res.code === 150 || res.code === 125) { // Ready to upload
+    return ftp.handle(command, (err, res, task) => {
+        if (err) {
+            ftp.enableControlTimeout(true);
+            progress.updateAndStop();
+            resolver.reject(task, err);
+        }
+        else if (res.code === 150 || res.code === 125) { // Ready to upload
             // If we are using TLS, we have to wait until the dataSocket issued
             // 'secureConnect'. If this hasn't happened yet, getCipher() returns undefined.
             // @ts-ignore that ftp.dataSocket might be just a Socket without getCipher()
@@ -776,13 +806,9 @@ function upload(ftp, progress, readableStream, remoteFilename) {
             });
         }
         else if (positiveCompletion(res.code)) { // Transfer complete
-            resolver.resolve(task, res.code);
+            resolver.resolve(task, res);
         }
-        else if (res.code >= 400 || res.error) {
-            ftp.enableControlTimeout(true);
-            progress.updateAndStop();
-            resolver.reject(task, res);
-        }
+        // Ignore any other FTP response
     });
 }
 
@@ -801,8 +827,13 @@ function download(ftp, progress, writableStream, command, remoteFilename = "") {
     // receives the announcement. Start listening for data immediately.
     ftp.dataSocket.pipe(writableStream);
     const resolver = new TransferResolver(ftp);
-    return ftp.handle(command, (res, task) => {
-        if (res.code === 150 || res.code === 125) { // Ready to download
+    return ftp.handle(command, (err, res, task) => {
+        if (err) {
+            ftp.enableControlTimeout(true);
+            progress.updateAndStop();
+            resolver.reject(task, err);
+        }
+        else if (res.code === 150 || res.code === 125) { // Ready to download
             ftp.log(`Downloading from ${describeAddress(ftp.dataSocket)} (${describeTLS(ftp.dataSocket)})`);
             // Let the data connection be in charge of tracking timeouts during transfer.
             ftp.enableControlTimeout(false);
@@ -821,13 +852,9 @@ function download(ftp, progress, writableStream, command, remoteFilename = "") {
             ftp.send("RETR " + remoteFilename);
         }
         else if (positiveCompletion(res.code)) { // Transfer complete
-            resolver.resolve(task, res.code);
+            resolver.resolve(task, res);
         }
-        else if (res.code >= 400 || res.error) {
-            ftp.enableControlTimeout(true);
-            progress.updateAndStop();
-            resolver.reject(task, res);
-        }
+        // Ignore any other FTP response
     });
 }
 

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -496,7 +496,7 @@ class TransferResolver {
     }
 
     /**
-     * @param {import("./FtpContext").Task} task
+     * @param {import("./FtpContext").TaskResolver} task
      */
     confirm(task) {
         this.confirmed = true;
@@ -504,7 +504,7 @@ class TransferResolver {
     }
 
     /**
-     * @param {import("./FtpContext").Task} task
+     * @param {import("./FtpContext").TaskResolver} task
      * @param {Error} err
      */
     reject(task, err) {
@@ -513,7 +513,7 @@ class TransferResolver {
     }
 
     /**
-     * @param {import("./FtpContext").Task} task
+     * @param {import("./FtpContext").TaskResolver} task
      * @param {import("./FtpContext").FTPResponse} response
      */
     resolve(task, response) {
@@ -522,7 +522,7 @@ class TransferResolver {
     }
 
     /**
-     * @param {import("./FtpContext").Task} task
+     * @param {import("./FtpContext").TaskResolver} task
      */
     _tryResolve(task) {
         if (this.confirmed && this.response !== undefined) {

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -802,7 +802,7 @@ function upload(ftp, progress, readableStream, remoteFilename) {
             // 'secureConnect'. If this hasn't happened yet, getCipher() returns undefined.
             // @ts-ignore that ftp.dataSocket might be just a Socket without getCipher()
             const canUpload = ftp.hasTLS === false || ftp.dataSocket.getCipher() !== undefined;
-            conditionOrEvent(canUpload, ftp.dataSocket, "secureConnect", () => {
+            onConditionOrEvent(canUpload, ftp.dataSocket, "secureConnect", () => {
                 ftp.log(`Uploading to ${describeAddress(ftp.dataSocket)} (${describeTLS(ftp.dataSocket)})`);
                 // Let the data socket be in charge of tracking timeouts.
                 // The control socket sits idle during this time anyway and might provoke
@@ -855,7 +855,7 @@ function download(ftp, progress, writableStream, command, remoteFilename = "") {
             // It's possible, though, that the data transmission is complete before
             // the control socket receives the accouncement that it will begin.
             // Check if the data socket is not already closed.
-            conditionOrEvent(ftp.dataSocket.destroyed, ftp.dataSocket, "end", () => {
+            onConditionOrEvent(ftp.dataSocket.destroyed, ftp.dataSocket, "end", () => {
                 ftp.enableControlTimeout(true);
                 progress.updateAndStop();
                 resolver.confirm(task);
@@ -880,7 +880,7 @@ function download(ftp, progress, writableStream, command, remoteFilename = "") {
  * @param {string} eventName  The event to subscribe to if the condition is not met.
  * @param {() => any} action  The function to call.
  */
-function conditionOrEvent(condition, emitter, eventName, action) {
+function onConditionOrEvent(condition, emitter, eventName, action) {
     if (condition === true) {
         action();
     }

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -632,8 +632,9 @@ function enterFirstCompatibleMode(...strategies) {
                 return res;
             }
             catch(err) {
-                if (!err.code) { // Don't log out FTP response error again.
-                    client.ftp.log(err.toString());
+                if (!(err instanceof FTPError)) {
+                    // Any other exception than FTPError should stop the evaluation of transfer strategies.
+                    throw err;
                 }
             }
         }

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -76,7 +76,7 @@ class Client {
             }
             else {
                 // Reject all other codes, including 120 "Service ready in nnn minutes".
-                task.reject(new Error(`Unexpected response from FTP server: ${res.message}`));
+                task.reject(new Error(`Unexpected server response: ${res.message}`));
             }
         });
     }

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -632,8 +632,10 @@ function enterFirstCompatibleMode(...strategies) {
                 return res;
             }
             catch(err) {
+                // Receiving an FTPError means that the last transfer strategy failed and we should
+                // try the next one. Any other exception should stop the evaluation of strategies because
+                // something else went wrong.
                 if (!(err instanceof FTPError)) {
-                    // Any other exception than FTPError should stop the evaluation of transfer strategies.
                     throw err;
                 }
             }

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -57,6 +57,13 @@ class Client {
     }
 
     /**
+     * @returns {boolean}
+     */
+    get closed() {
+        return this.ftp.closed;
+    }
+
+    /**
      * Connect to an FTP server.
      *
      * @param {string} [host=localhost]  Host the client should connect to.

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -535,6 +535,7 @@ class TransferResolver {
 module.exports = {
     Client,
     FTPContext,
+    FTPError,
     FileInfo,
     // Expose some utilities for custom extensions:
     utils: {

--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -47,7 +47,9 @@ class Client {
     }
 
     /**
-     * Close all connections. You may continue using this client instance and reconnect again.
+     * Close the client and all open socket connections.
+     *
+     * The client can’t be used anymore after calling this method, you have to instantiate a new one to continue any work.
      */
     close() {
         this.ftp.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-ftp",
-  "version": "2.17.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-ftp",
-  "version": "2.17.1",
+  "version": "3.0.0",
   "description": "FTP client for Node.js with support for explicit FTPS over TLS.",
   "main": "./lib/ftp",
   "scripts": {

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -84,7 +84,7 @@ describe("Convenience API", function() {
             func: c => c.send("TEST"),
             command: "TEST\r\n",
             reply: "500 Error\r\n",
-            result: new FTPError("500 Error")
+            result: new FTPError({code: 500, message: "500 Error"})
         },
         {
             name: "send command: can optionally ignore error response (>=400)",

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -98,7 +98,7 @@ describe("Convenience API", function() {
             func: c => c.send("TEST", true),
             command: "TEST\r\n",
             reply: undefined,
-            result: new Error("some error")
+            result: new Error("some error (control)")
         },
         {
             name: "can get the working directory",

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -98,7 +98,7 @@ describe("Convenience API", function() {
             func: c => c.send("TEST", true),
             command: "TEST\r\n",
             reply: undefined,
-            result: new Error("some error (control)")
+            result: new Error("some error (control socket)")
         },
         {
             name: "can get the working directory",

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -163,7 +163,7 @@ describe("Convenience API", function() {
         client.ftp.socket.connect = () => {
             setTimeout(() => client.ftp.socket.emit("data", "120 Ready in 5 hours"));
         };
-        return client.connect("host", 22).catch(result => assert.deepEqual(result, new Error("Unexpected response from FTP server: 120 Ready in 5 hours")));
+        return client.connect("host", 22).catch(result => assert.deepEqual(result, new Error("Unexpected server response: 120 Ready in 5 hours")));
     });
 
     it("can login", function() {

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -163,7 +163,7 @@ describe("Convenience API", function() {
         client.ftp.socket.connect = () => {
             setTimeout(() => client.ftp.socket.emit("data", "120 Ready in 5 hours"));
         };
-        return client.connect("host", 22).catch(result => assert.deepEqual(result, new Error("Unexpected server response: 120 Ready in 5 hours")));
+        return client.connect("host", 22).catch(result => assert.deepEqual(result, new FTPError({code: 120, message: "120 Ready in 5 hours"})));
     });
 
     it("can login", function() {
@@ -186,6 +186,6 @@ describe("Convenience API", function() {
         client.ftp.socket.once("didSend", () => {
             client.ftp.socket.emit("data", "332 Account needed");
         });
-        return client.login("user", "pass").catch(result => assert.deepEqual(result, new Error("Unexpected response from FTP server: 332 Account needed")));
+        return client.login("user", "pass").catch(result => assert.deepEqual(result, new FTPError({code: 332, message: "332 Account needed"})));
     });
 });

--- a/test/downloadSpec.js
+++ b/test/downloadSpec.js
@@ -112,16 +112,15 @@ describe("Download directory listing", function() {
         });
     });
 
-    it("relays FTP error response even if data transmitted completely", function(done) {
-        client.list().catch(err => {
-            assert.deepEqual(err, new FTPError("500 Error"));
-            done();
-        });
+    it("relays FTP error response even if data transmitted completely", function() {
         setTimeout(() => {
             client.ftp.socket.emit("data", "125 Sending");
             client.ftp.dataSocket.emit("data", bufList);
             client.ftp.dataSocket.end();
             client.ftp.socket.emit("data", "500 Error");
+        });
+        return client.list().catch(err => {
+            assert.deepEqual(err, new FTPError({code: 500, message: "500 Error"}));
         });
     });
 });

--- a/test/downloadSpec.js
+++ b/test/downloadSpec.js
@@ -2,6 +2,7 @@ const assert = require("assert");
 const Client = require("../lib/ftp").Client;
 const FileInfo = require("../lib/ftp").FileInfo;
 const SocketMock = require("./SocketMock");
+const { FTPError } = require("../lib/FtpContext");
 
 /**
  * Downloading a directory listing uses the same mechanism as downloading in general,
@@ -113,8 +114,7 @@ describe("Download directory listing", function() {
 
     it("relays FTP error response even if data transmitted completely", function(done) {
         client.list().catch(err => {
-            assert.equal(err.code, 500, "Error code");
-            assert.equal(err.message, "500 Error");
+            assert.deepEqual(err, new FTPError("500 Error"));
             done();
         });
         setTimeout(() => {

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -139,7 +139,7 @@ describe("FTPContext", function() {
     it("queues an error if no task is active and assigns it to the next task", function() {
         ftp.socket.emit("error", new Error("some error"));
         return ftp.handle("TEST", (err, res, task) => {
-            assert.deepEqual(err, new Error("some error (control socket)"));
+            assert.deepEqual(err, new Error("Client has been closed earlier, reason: some error (control socket)"));
             task.resolve();
         });
     });

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -139,7 +139,7 @@ describe("FTPContext", function() {
     it("queues an error if no task is active and assigns it to the next task", function() {
         ftp.socket.emit("error", new Error("some error"));
         return ftp.handle("TEST", (err, res, task) => {
-            assert.deepEqual(err, new Error("Client has been closed earlier, reason: some error (control socket)"));
+            assert.deepEqual(err, new Error("Client has been closed earlier: some error (control socket)"));
             task.resolve();
         });
     });

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -139,7 +139,7 @@ describe("FTPContext", function() {
     it("queues an error if no task is active and assigns it to the next task", function() {
         ftp.socket.emit("error", new Error("some error"));
         return ftp.handle("TEST", (err, res, task) => {
-            assert.deepEqual(err, new Error("Client has been closed earlier: some error (control socket)"));
+            assert.deepEqual(err, new Error("Client has been closed: some error (control socket)"));
             task.resolve();
         });
     });

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -139,7 +139,9 @@ describe("FTPContext", function() {
     it("queues an error if no task is active and assigns it to the next task", function() {
         ftp.socket.emit("error", new Error("some error"));
         return ftp.handle("TEST", (err, res, task) => {
-            assert.deepEqual(err, new Error("Client has been closed: some error (control socket)"));
+            err = new Error("Client has been closed: some error (control socket)");
+            err.code = 0;
+            assert.deepEqual(err, err);
             task.resolve();
         });
     });

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -33,7 +33,7 @@ describe("FTPContext", function() {
 
     it("Relays control socket timeout event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("Socket timeout (control socket)"));
+            assert.deepEqual(err, new Error("Timeout (control socket)"));
             done();
         });
         ftp.socket.emit("timeout");
@@ -49,7 +49,7 @@ describe("FTPContext", function() {
 
     it("Relays data socket timeout event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("Socket timeout (data socket)"));
+            assert.deepEqual(err, new Error("Timeout (data socket)"));
             done();
         });
         ftp.dataSocket.emit("timeout");

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -33,7 +33,7 @@ describe("FTPContext", function() {
 
     it("Relays control socket timeout event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("Socket timeout (control)"));
+            assert.deepEqual(err, new Error("Socket timeout (control socket)"));
             done();
         });
         ftp.socket.emit("timeout");
@@ -41,7 +41,7 @@ describe("FTPContext", function() {
 
     it("Relays control socket error event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("hello (control)"));
+            assert.deepEqual(err, new Error("hello (control socket)"));
             done();
         });
         ftp.socket.emit("error", new Error("hello"));
@@ -49,7 +49,7 @@ describe("FTPContext", function() {
 
     it("Relays data socket timeout event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("Socket timeout (data)"));
+            assert.deepEqual(err, new Error("Socket timeout (data socket)"));
             done();
         });
         ftp.dataSocket.emit("timeout");
@@ -57,7 +57,7 @@ describe("FTPContext", function() {
 
     it("Relays data socket error event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("hello (data)"));
+            assert.deepEqual(err, new Error("hello (data socket)"));
             done();
         });
         ftp.dataSocket.emit("error", new Error("hello"));

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -41,7 +41,7 @@ describe("FTPContext", function() {
 
     it("Relays control socket error event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("hello"));
+            assert.deepEqual(err, new Error("hello (control)"));
             done();
         });
         ftp.socket.emit("error", new Error("hello"));
@@ -57,7 +57,7 @@ describe("FTPContext", function() {
 
     it("Relays data socket error event", function(done) {
         ftp.handle(undefined, err => {
-            assert.deepEqual(err, new Error("hello"));
+            assert.deepEqual(err, new Error("hello (data)"));
             done();
         });
         ftp.dataSocket.emit("error", new Error("hello"));

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -32,39 +32,39 @@ describe("FTPContext", function() {
     });
 
     it("Relays control socket timeout event", function(done) {
-        ftp.handle(undefined, res => {
-            assert.deepEqual(res, { error: { info: "socket timeout", ftpSocket: "control" }});
+        ftp.handle(undefined, err => {
+            assert.deepEqual(err, new Error("Socket timeout (control)"));
             done();
         });
         ftp.socket.emit("timeout");
     });
 
     it("Relays control socket error event", function(done) {
-        ftp.handle(undefined, res => {
-            assert.deepEqual(res, { error: { foo: "bar", ftpSocket: "control" } });
+        ftp.handle(undefined, err => {
+            assert.deepEqual(err, new Error("hello"));
             done();
         });
-        ftp.socket.emit("error", { foo: "bar" });
+        ftp.socket.emit("error", new Error("hello"));
     });
 
     it("Relays data socket timeout event", function(done) {
-        ftp.handle(undefined, res => {
-            assert.deepEqual(res, { error: { info: "socket timeout", ftpSocket: "data" }});
+        ftp.handle(undefined, err => {
+            assert.deepEqual(err, new Error("Socket timeout (data)"));
             done();
         });
         ftp.dataSocket.emit("timeout");
     });
 
     it("Relays data socket error event", function(done) {
-        ftp.handle(undefined, res => {
-            assert.deepEqual(res, { error: { foo: "bar", ftpSocket: "data" } });
+        ftp.handle(undefined, err => {
+            assert.deepEqual(err, new Error("hello"));
             done();
         });
-        ftp.dataSocket.emit("error", { foo: "bar" });
+        ftp.dataSocket.emit("error", new Error("hello"));
     });
 
     it("Relays single line control response", function(done) {
-        ftp.handle(undefined, res => {
+        ftp.handle(undefined, (err, res) => {
             assert.deepEqual(res, { code: 200, message: "200 OK"});
             done();
         });
@@ -72,7 +72,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays multiline control response", function(done) {
-        ftp.handle(undefined, res => {
+        ftp.handle(undefined, (err, res) => {
             assert.deepEqual(res, { code: 200, message: "200-OK\nHello\n200 OK"});
             done();
         });
@@ -81,7 +81,7 @@ describe("FTPContext", function() {
 
     it("Relays multiple multiline control responses in separate callbacks", function(done) {
         const exp = new Set(["200-OK\n200 OK", "200-Again\n200 Again" ]);
-        ftp.handle(undefined, res => {
+        ftp.handle(undefined, (err, res) => {
             assert.equal(true, exp.has(res.message));
             exp.delete(res.message);
             if (exp.size === 0) {
@@ -92,7 +92,7 @@ describe("FTPContext", function() {
     });
 
     it("Relays chunked multiline response as a single response", function(done) {
-        ftp.handle(undefined, res => {
+        ftp.handle(undefined, (err, res) => {
             assert.deepEqual(res, { code: 200, message: "200-OK\nHello\n200 OK"});
             done();
         });
@@ -101,7 +101,7 @@ describe("FTPContext", function() {
     });
 
     it("Stops relaying if task is resolved", function(done) {
-        ftp.handle(undefined, (res, task) => {
+        ftp.handle(undefined, (err, res, task) => {
             if (res.code === 220) {
                 assert.fail("Relayed message when it shouldn't have.");
             }

--- a/test/uploadSpec.js
+++ b/test/uploadSpec.js
@@ -18,7 +18,6 @@ describe("Upload", function() {
     });
 
     afterEach(function() {
-        client.ftp._reset();
         client.close();
     });
 
@@ -27,7 +26,7 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "STOR NAME.TXT\r\n");
             done();
         });
-        client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT").catch(() => {});
     });
 
     it("starts uploading after receiving 'ready to upload'", function(done) {
@@ -37,7 +36,7 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "123", "Wrong data sent");
             done();
         });
-        client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT").catch(() => {});
         setTimeout(() => {
             didSendReady = true;
             client.ftp.socket.emit("data", "150 Ready");
@@ -53,7 +52,7 @@ describe("Upload", function() {
             assert.equal(buf.toString(), "123", "Wrong data sent");
             done();
         });
-        client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT").catch(() => {});
         setTimeout(() => {
             client.ftp.socket.emit("data", "150 Ready");
             setTimeout(() => {
@@ -72,7 +71,7 @@ describe("Upload", function() {
                 done();
             });
         });
-        client.upload(readable, "NAME.TXT");
+        client.upload(readable, "NAME.TXT").catch(() => {});
         setTimeout(() => {
             client.ftp.socket.emit("data", "150 Ready");
             // Don't send completion message, we don't want the TransferResolver

--- a/test/uploadSpec.js
+++ b/test/uploadSpec.js
@@ -1,7 +1,8 @@
 const assert = require("assert");
+const fs = require("fs");
 const Client = require("../lib/ftp").Client;
 const SocketMock = require("./SocketMock");
-const fs = require("fs");
+const { FTPError } = require("../lib/FtpContext");
 
 describe("Upload", function() {
     this.timeout(100);
@@ -99,15 +100,13 @@ describe("Upload", function() {
         return promise;
     });
 
-    it("handles errors", function(done) {
-        client.upload(readable, "NAME.TXT").catch(err => {
-            assert.equal(err.code, 500, "Error code");
-            assert.equal(err.message, "500 Error", "Error message");
-            done();
-        });
+    it("handles errors", function() {
         setTimeout(() => {
             client.ftp.socket.emit("data", "150 Ready");
             client.ftp.socket.emit("data", "500 Error");
+        });
+        return client.upload(readable, "NAME.TXT").catch(err => {
+            assert.deepEqual(err, new FTPError("500 Error"));
         });
     });
 });

--- a/test/uploadSpec.js
+++ b/test/uploadSpec.js
@@ -106,7 +106,7 @@ describe("Upload", function() {
             client.ftp.socket.emit("data", "500 Error");
         });
         return client.upload(readable, "NAME.TXT").catch(err => {
-            assert.deepEqual(err, new FTPError("500 Error"));
+            assert.deepEqual(err, new FTPError({code: 500, message: "500 Error"}));
         });
     });
 });


### PR DESCRIPTION
On the way to Version 3.

- [x] Use Error instances
- [x] Clarify and simplify failure paths, what happens in which order
- [x] Make FTPContext single-use
- [x] Handle errors outside of tasks
- [x] Update documentation
- [x] Offer good debugging help when user forgets to await a task

Fixes: #43 , #37, #36 