### PR TITLE
Client.list now supports a path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Change the working directory.
 
 Get the path of the current working directory.
 
-`list(): Promise<FileInfo[]>`
+`list([path]): Promise<FileInfo[]>`
 
-List files and directories in the current working directory. Currently, this library only supports Unix- and DOS-style directory listings.
+List files and directories in the current working directory, or from `path` if specified. Currently, this library only supports Unix- and DOS-style directory listings.
 
 `lastMod(filename): Promise<Date>`
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -367,15 +367,15 @@ export class Client {
 
     /**
      * List files and directories in the current working directory.
-     * 
-     * @param path The name of the remote file or directory. If undefined, will use current directory 
+     *
+     * @param path The name of the remote file or directory. If undefined, will use current directory
      */
     async list(path?: string): Promise<FileInfo[]> {
         await this.prepareTransfer(this)
         const writable = new StringWriter()
         const progressTracker = createNullObject() as ProgressTracker // Don't track progress of list transfers.
-        const command = path ? `LIST ${path}` : "LIST -a";
-        await download(this.ftp, progressTracker, writable, command);
+        const command = path ? `LIST ${path}` : "LIST -a"
+        await download(this.ftp, progressTracker, writable, command)
         const text = writable.getText(this.ftp.encoding)
         this.ftp.log(text)
         return this.parseList(text)

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -371,10 +371,11 @@ export class Client {
      * @param path The name of the remote file or directory. If undefined, will use current directory
      */
     async list(path?: string): Promise<FileInfo[]> {
+        const validPath = path && await this.protectWhitespace(path)
         await this.prepareTransfer(this)
         const writable = new StringWriter()
         const progressTracker = createNullObject() as ProgressTracker // Don't track progress of list transfers.
-        const command = path ? `LIST ${path}` : "LIST -a"
+        const command = "LIST -a" + (validPath ? ` ${validPath}` : "")
         await download(this.ftp, progressTracker, writable, command)
         const text = writable.getText(this.ftp.encoding)
         this.ftp.log(text)

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -367,12 +367,15 @@ export class Client {
 
     /**
      * List files and directories in the current working directory.
+     * 
+     * @param path The name of the remote file or directory. If undefined, will use current directory 
      */
-    async list(): Promise<FileInfo[]> {
+    async list(path?: string): Promise<FileInfo[]> {
         await this.prepareTransfer(this)
         const writable = new StringWriter()
         const progressTracker = createNullObject() as ProgressTracker // Don't track progress of list transfers.
-        await download(this.ftp, progressTracker, writable, "LIST -a")
+        const command = path ? `LIST ${path}` : "LIST -a";
+        await download(this.ftp, progressTracker, writable, command);
         const text = writable.getText(this.ftp.encoding)
         this.ftp.log(text)
         return this.parseList(text)


### PR DESCRIPTION
I needed to get the stats of specific files and I didn't want to `cd` into each directory before doing this.