### PR TITLE
Add additional check for EPSV responses containing ! instead of |

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -667,7 +667,12 @@ export async function enterPassiveModeIPv6(client: Client): Promise<FTPResponse>
  */
 function parseIPv6PasvResponse(message: string): number {
     // Get port from EPSV response, e.g. "229 Entering Extended Passive Mode (|||6446|)"
-    const groups = message.match(/\|{3}(.+)\|/)
+    let groups = message.match(/\|{3}(.+)\|/)
+
+    if (groups === null || groups[1] === undefined) {
+        // Some FTP Servers such as the one on IBM i (OS/400) use ! instead of | in their EPSV response.
+        groups = message.match(/!{3}(.+)!/)
+    }
     if (groups === null || groups[1] === undefined) {
         throw new Error(`Can't parse response to 'EPSV': ${message}`)
     }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -667,12 +667,8 @@ export async function enterPassiveModeIPv6(client: Client): Promise<FTPResponse>
  */
 function parseIPv6PasvResponse(message: string): number {
     // Get port from EPSV response, e.g. "229 Entering Extended Passive Mode (|||6446|)"
-    let groups = message.match(/\|{3}(.+)\|/)
-
-    if (groups === null || groups[1] === undefined) {
-        // Some FTP Servers such as the one on IBM i (OS/400) use ! instead of | in their EPSV response.
-        groups = message.match(/!{3}(.+)!/)
-    }
+    // Some FTP Servers such as the one on IBM i (OS/400) use ! instead of | in their EPSV response.
+    const groups = message.match(/[|!]{3}(.+)[|!]/)
     if (groups === null || groups[1] === undefined) {
         throw new Error(`Can't parse response to 'EPSV': ${message}`)
     }


### PR DESCRIPTION
Apparently some legacy FTP servers like the one on the IBM i or z/OS respond with 

```
229 Entering Extended Passive Mode (!!!9447!).
```
instead of 
```
229 Entering Extended Passive Mode (|||9447|).
```

Added a check and match for those cases.

All unit tests passed except the ones that seem broken pointed out in https://github.com/patrickjuchli/basic-ftp/issues/86