### PR TITLE
Allow 'undefined' to be passed to trackProgress

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Report any transfer progress using the given handler function. See the next sect
 
 ## Transfer Progress
 
-Set a callback function with `client.trackProgress` to track the progress of any transfer. Transfers are uploads, downloads or directory listings. To disable progress reporting, call `trackProgress` with an undefined handler.
+Set a callback function with `client.trackProgress` to track the progress of any transfer. Transfers are uploads, downloads or directory listings. To disable progress reporting, call `trackProgress` without a handler.
 
 ```js
 // Log progress for any transfer from now on.

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -350,7 +350,7 @@ export class Client {
      *
      * @param handler  Handler function to call on transfer progress.
      */
-    trackProgress(handler: ProgressHandler | undefined) {
+    trackProgress(handler?: ProgressHandler) {
         this._progressTracker.bytesOverall = 0
         this._progressTracker.reportTo(handler)
     }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -346,7 +346,7 @@ export class Client {
      * Report transfer progress for any upload or download to a given handler.
      *
      * This will also reset the overall transfer counter that can be used for multiple transfers. You can
-     * also pass `undefined` as a handler to stop reporting to an earlier one.
+     * also call the function without a handler to stop reporting to an earlier one.
      *
      * @param handler  Handler function to call on transfer progress.
      */

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -350,7 +350,7 @@ export class Client {
      *
      * @param handler  Handler function to call on transfer progress.
      */
-    trackProgress(handler: ProgressHandler) {
+    trackProgress(handler: ProgressHandler | undefined) {
         this._progressTracker.bytesOverall = 0
         this._progressTracker.reportTo(handler)
     }


### PR DESCRIPTION
The documentation states that 'undefined' is also a valid parameter. Typescript complains about this, because the type only allows `ProgressHandler`.