### PR TITLE
Add custom socket function for proxy use

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -111,12 +111,21 @@ export class Client {
      */
     connect(host = "localhost", port = 21): Promise<FTPResponse> {
         this.ftp.reset()
-        this.ftp.socket.connect({
-            host,
-            port,
-            family: this.ftp.ipFamily
-        }, () => this.ftp.log(`Connected to ${describeAddress(this.ftp.socket)} (${describeTLS(this.ftp.socket)})`))
-        return this._handleConnectResponse()
+        return new Promise((resolve, reject) => {
+            this.ftp.createConnection((err, s) => {
+                if (err) {
+                    reject(err)
+                    return
+                }
+                this.ftp.socket = s
+                resolve(s)
+            },{
+                host, port, family: this.ftp.ipFamily
+            }, () => {
+                this.ftp.log(`Connected to ${describeAddress(this.ftp.socket)} (${describeTLS(this.ftp.socket)})`)
+            })
+        })
+          .then(() => this._handleConnectResponse())
     }
 
     /**

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -84,9 +84,10 @@ export function connectForPassiveTransfer(host: string, port: number, ftp: FTPCo
             err.message = "Can't open data connection in passive mode: " + err.message
             reject(err)
         }
-        let socket = ftp._newSocket()
-        socket.on("error", handleConnErr)
-        socket.connect({ port, host, family: ftp.ipFamily }, () => {
+        ftp.createConnection(s => {
+            s.on("error", handleConnErr)
+        }, { port, host, family: ftp.ipFamily }, s => {
+            let socket = s
             if (ftp.socket instanceof TLSSocket) {
                 socket = connectTLS(Object.assign({}, ftp.tlsOptions, {
                     socket,

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -84,7 +84,11 @@ export function connectForPassiveTransfer(host: string, port: number, ftp: FTPCo
             err.message = "Can't open data connection in passive mode: " + err.message
             reject(err)
         }
-        ftp.createConnection(s => {
+        ftp.createConnection((err, s) => {
+            if (err) {
+               handleConnErr(err)
+               return
+            }
             s.on("error", handleConnErr)
         }, { port, host, family: ftp.ipFamily }, s => {
             let socket = s


### PR DESCRIPTION
It is possible to use proxy through socks socket.

* npm run test: OK

An example using the [socks](https://www.npmjs.com/package/socks) library:
```typescript

          ftpClient.ftp.createConnection = (preparer, options: net.SocketConnectOpts, connectionListener) => {
            const sockOpts = options as net.TcpSocketConnectOpts;
            SocksClient.createConnection({
              proxy: {
                ...
              },
              command: 'connect',
              destination: {
                host: sockOpts.host as string,
                port: sockOpts.port
              }
            })
              .then(evt => {
                if (preparer) {
                  preparer(null, evt.socket)
                }
                if (connectionListener) {
                  connectionListener(evt.socket);
                }
              })
              .catch(e => {
                if (preparer) {
                  preparer(e, null as any)
                }
              })
          };
```