### PR TITLE
Added updates needed for using the client with proxies.

### DIFF
--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -21,7 +21,7 @@ export async function enterPassiveModeIPv6(ftp: FTPContext): Promise<FTPResponse
     if (controlHost === undefined) {
         throw new Error("Control socket is disconnected, can't get remote address.")
     }
-    await connectForPassiveTransfer(controlHost, port, ftp)
+    await connectForPassiveTransfer(ftp.config.useInitialHost && ftp.connectedTo.host ? ftp.connectedTo.host : controlHost, port, ftp)
     return res
 }
 
@@ -56,7 +56,9 @@ export async function enterPassiveModeIPv4(ftp: FTPContext): Promise<FTPResponse
     // We can't always perform this replacement because it's possible (although unlikely) that the FTP server
     // indeed uses a different host for data connections.
     const controlHost = ftp.socket.remoteAddress
-    if (ipIsPrivateV4Address(target.host) && controlHost && !ipIsPrivateV4Address(controlHost)) {
+    if(ftp.config.useInitialHost) {
+        target.host = ftp.connectedTo.host
+    } else if (ipIsPrivateV4Address(target.host) && controlHost && !ipIsPrivateV4Address(controlHost)) {
         target.host = controlHost
     }
     await connectForPassiveTransfer(target.host, target.port, ftp)

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -18,8 +18,10 @@ describe("Convenience API", function() {
     let client;
 
     beforeEach(function() {
-        client = new Client(2000);
-        client.ftp._newSocket = () => new SocketMock();
+        client = new Client({
+            timeout: 2000,
+            buildSocket: () => new SocketMock()
+        });
         client.prepareTransfer = () => Promise.resolve({code: 200, message: "ok"}); // Don't change
         client.ftp.socket = new SocketMock();
         client.ftp.dataSocket = new SocketMock();
@@ -165,6 +167,8 @@ describe("Convenience API", function() {
         client.close()
         client.connect().catch(() => {})
         assert.equal(client.closed, false)
+        assert.equal(client.ftp.connectedTo.host, '')
+        assert.equal(client.ftp.connectedTo.port, 0)
     })
 
     it("closing client reports client as closed", function() {
@@ -175,6 +179,12 @@ describe("Convenience API", function() {
     it("client is described as closed when not connected yet", function() {
         const realClient = new Client()
         assert.equal(realClient.closed, true)
+    })
+
+    it("client can be initialized with timeout only", function() {
+        const realClient = new Client(1500)
+        assert.equal(realClient.ftp.timeout, 1500)
+        assert.equal(realClient.ftp.encoding, "utf8")
     })
 
     it("declines connect for code 120", function() {

--- a/test/ftpContextSpec.js
+++ b/test/ftpContextSpec.js
@@ -174,4 +174,32 @@ describe("FTPContext", function() {
             assert.equal(c.socket.timeout, 0, "timeout after resolving task");
         });
     });
+
+    it("reset set a new socket and clear connection info", function() {
+        const initialSocket = new SocketMock()
+        const c = new FTPContext(10000);
+        c.socket = initialSocket;
+        c._setupConnectedTo('host', 2121)
+
+        c.reset()
+
+        assert.notEqual(c.socket, initialSocket)
+        assert.equal(c.connectedTo.host, '')
+        assert.equal(c.connectedTo.port, 0)
+    });
+
+    it("_setupConnectedTo sets data correctly", function() {
+        const c = new FTPContext(10000);
+        c._setupConnectedTo('host', 2121)
+        assert.equal(c.connectedTo.host, 'host')
+        assert.equal(c.connectedTo.port, 2121)
+    });
+
+    it("_setupConnectedTo without params clears info", function() {
+        const c = new FTPContext(10000);
+        c._setupConnectedTo('host', 2121)
+        c._setupConnectedTo()
+        assert.equal(c.connectedTo.host, '')
+        assert.equal(c.connectedTo.port, 0)
+    });
 });


### PR DESCRIPTION
Added configuration params what made newSocket configurable and new useInitialHost that makes client using the host provided during connection.  It is needed to allow connecting through different proxy sockets. For example the following code  connects to an ftp server through SOCKS5 proxy:
```javascript
const client = new ftp.Client({
   useInitialHost: true,
   buildSocket: () => proxysocket.create('host', 8888)
});

client.ftp.verbose = true;

await client.access({ host: 'speedtest.tele2.net', port: 21 });

const tList = await client.list();
for (const tFile of tList) {
   console.log(tFile);
}
client.close();
```