### PR TITLE
Warn modern users about different ESM/TS import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Node 8.0 or later is the only dependency.
 The first example will connect to an FTP server using TLS, get a directory listing, upload a file and download it as a copy. Note that the FTP protocol doesn't allow multiple requests running in parallel.
 
 ```js
+// ESM and TypeScript: import * as ftp from 'basic-ftp'
 const ftp = require("basic-ftp")
 
 example()


### PR DESCRIPTION
I spent way too long checking my tsconfig/package.json because of this.

Related to #183 