### PR TITLE
fix - ECONNRESET in datasocket unnecessarily closes the controlsocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint-fix": "eslint --fix \"./src/**/*.ts\"",
     "dev": "npm run clean && tsc --watch",
     "tdd": "mocha --watch",
+    "prepare": "tsc",
     "buildOnly": "tsc"
   },
   "repository": {

--- a/test/downloadSpec.js
+++ b/test/downloadSpec.js
@@ -158,7 +158,7 @@ describe("Download to stream", function() {
         })
         
         const buf = new StringWriter()
-        await this.client.downloadTo(buf, FILENAME)
+        await this.client.downloadTo(buf, FILENAME).catch(err => {})
         //control socket should still be open
         assert(this.client.ftp.socket?.writable)
     })


### PR DESCRIPTION
Some FTP Servers just abruptly end the data connection. This happens for example for the NLST command when given a wrong path (probably unintentionally).
Currently this library closes the control socket instantly when there's an error in the data connection. When actually, the control socket could survive.